### PR TITLE
Improve `AnyNavigationTransition` internals

### DIFF
--- a/Sources/NavigationTransition/AnyNavigationTransition.swift
+++ b/Sources/NavigationTransition/AnyNavigationTransition.swift
@@ -2,7 +2,7 @@ import Animation
 import UIKit
 
 public struct AnyNavigationTransition {
-    @_spi(package)public typealias Handler = (
+    @_spi(package)public typealias TransientHandler = (
         AnimatorTransientView,
         AnimatorTransientView,
         NavigationTransitionOperation,
@@ -15,21 +15,23 @@ public struct AnyNavigationTransition {
         UIViewControllerContextTransitioning
     ) -> Void
 
+    @_spi(package)public enum Handler {
+        case transient(TransientHandler)
+        case primitive(PrimitiveHandler)
+    }
+
     @_spi(package)public let type: Any.Type
-    @_spi(package)public let handler: Handler?
-    @_spi(package)public let primitiveHandler: PrimitiveHandler?
+    @_spi(package)public let handler: Handler
     @_spi(package)public var animation: Animation = .default
 
     public init<T: NavigationTransition>(_ transition: T) {
         self.type = Swift.type(of: transition)
-        self.handler = transition.transition(from:to:for:in:)
-        self.primitiveHandler = nil
+        self.handler = .transient(transition.transition(from:to:for:in:))
     }
 
     public init<T: PrimitiveNavigationTransition>(_ transition: T) {
         self.type = Swift.type(of: transition)
-        self.handler = nil
-        self.primitiveHandler = transition.transition(with:for:in:)
+        self.handler = .primitive(transition.transition(with:for:in:))
     }
 }
 

--- a/Sources/NavigationTransition/Combined.swift
+++ b/Sources/NavigationTransition/Combined.swift
@@ -14,7 +14,7 @@ extension AnyNavigationTransition {
                 """
                 Combining primitive and non-primitive or two primitive transitions via 'combine(with:)' is not allowed.
 
-                The left-hand side transition will be left unmodified and the other transition will be discarded.
+                The left-hand side transition will be left unmodified and the right-hand side transition will be discarded.
                 """
             )
             return self

--- a/Sources/NavigationTransition/Combined.swift
+++ b/Sources/NavigationTransition/Combined.swift
@@ -2,17 +2,23 @@ extension AnyNavigationTransition {
     /// Combines this transition with another, returning a new transition that is the result of both transitions
     /// being applied.
     public func combined(with other: Self) -> Self {
-        guard let lhsHandler = self.handler, let rhsHandler = other.handler else {
+        switch (self.handler, other.handler) {
+        case (.transient(let lhsHandler), .transient(let rhsHandler)):
+            return AnyNavigationTransition(
+                Combined(Erased(handler: lhsHandler), Erased(handler: rhsHandler))
+            )
+        case (.transient, .primitive),
+             (.primitive, .transient),
+             (.primitive, .primitive):
             runtimeWarn(
                 """
-                Combining primitive and non-primitive transitions via 'combine(with:)' is not allowed.
+                Combining primitive and non-primitive or two primitive transitions via 'combine(with:)' is not allowed.
+
+                The left-hand side transition will be left unmodified and the other transition will be discarded.
                 """
             )
             return self
         }
-        return .init(
-            Combined(Erased(handler: lhsHandler), Erased(handler: rhsHandler))
-        )
     }
 }
 

--- a/Sources/NavigationTransition/Erased.swift
+++ b/Sources/NavigationTransition/Erased.swift
@@ -1,8 +1,8 @@
 // A type erased transition for internal use only.
 struct Erased: NavigationTransition {
-    private let handler: AnyNavigationTransition.Handler
+    private let handler: AnyNavigationTransition.TransientHandler
 
-    init(handler: @escaping AnyNavigationTransition.Handler) {
+    init(handler: @escaping AnyNavigationTransition.TransientHandler) {
         self.handler = handler
     }
 

--- a/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
+++ b/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
@@ -71,19 +71,18 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
             timingParameters: transition.animation.timingParameters
         )
 
-        // Handle NavigationTransition setup
-        if let (fromView, toView) = transientViews(for: transition, animator: animator, context: transitionContext) {
-            fromView.setUIViewProperties(to: \.initial)
-            animator.addAnimations { fromView.setUIViewProperties(to: \.animation) }
-            animator.addCompletion { _ in fromView.setUIViewProperties(to: \.completion) }
+        switch transition.handler {
+        case .transient(let handler):
+            if let (fromView, toView) = transientViews(for: handler, animator: animator, context: transitionContext) {
+                fromView.setUIViewProperties(to: \.initial)
+                animator.addAnimations { fromView.setUIViewProperties(to: \.animation) }
+                animator.addCompletion { _ in fromView.setUIViewProperties(to: \.completion) }
 
-            toView.setUIViewProperties(to: \.initial)
-            animator.addAnimations { toView.setUIViewProperties(to: \.animation) }
-            animator.addCompletion { _ in toView.setUIViewProperties(to: \.completion) }
-        }
-
-        // Handle PrimitiveNavigationTransition setup
-        if let handler = transition.primitiveHandler {
+                toView.setUIViewProperties(to: \.initial)
+                animator.addAnimations { toView.setUIViewProperties(to: \.animation) }
+                animator.addCompletion { _ in toView.setUIViewProperties(to: \.completion) }
+            }
+        case .primitive(let handler):
             handler(animator, operation, transitionContext)
         }
 
@@ -96,12 +95,11 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
     }
 
     private func transientViews(
-        for transition: AnyNavigationTransition,
+        for handler: AnyNavigationTransition.TransientHandler,
         animator: Animator,
         context: UIViewControllerContextTransitioning
     ) -> (fromView: AnimatorTransientView, toView: AnimatorTransientView)? {
         guard
-            let handler = transition.handler,
             let fromUIView = context.view(forKey: .from),
             let fromUIViewSnapshot = fromUIView.snapshotView(afterScreenUpdates: false),
             let toUIView = context.view(forKey: .to),

--- a/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
+++ b/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
@@ -65,11 +65,11 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
         if let cached = cachedAnimators[ObjectIdentifier(transitionContext)] {
             return cached
         }
-
         let animator = UIViewPropertyAnimator(
             duration: transitionDuration(using: transitionContext),
             timingParameters: transition.animation.timingParameters
         )
+        cachedAnimators[ObjectIdentifier(transitionContext)] = animator
 
         switch transition.handler {
         case .transient(let handler):
@@ -90,7 +90,6 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
 
-        cachedAnimators[ObjectIdentifier(transitionContext)] = animator
         return animator
     }
 


### PR DESCRIPTION
Specifically, model handlers as an enum instead of two optionals. This helps avoid awkward code paths.