### PR TITLE
Deprecate split view modifiers

### DIFF
--- a/Demo/Demo/Pages.swift
+++ b/Demo/Demo/Pages.swift
@@ -35,13 +35,13 @@ struct PageOne: View {
 struct PageTwo: View {
     var body: some View {
         let content = Group {
-            Text("The library is fully compatible with **NavigationView** in iOS 13+, and the new **NavigationStack** and **NavigationSplitView** in iOS 16.")
+            Text("The library is fully compatible with **NavigationView** in iOS 13+, and the new **NavigationStack** in iOS 16.")
             Text("In fact, that entire transition you just saw can be implemented in **one line** of SwiftUI code:")
             Code("""
-                NavigationView {
+                NavigationStack {
                   ...
                 }
-                .navigationViewStackTransition(.slide)
+                .navigationTransition(.slide)
                 """
             )
         }
@@ -62,7 +62,7 @@ struct PageThree: View {
             Text("The API is designed to resemble that of built-in SwiftUI Transitions for maximum **familiarity** and **ease of use**.")
             Text("You can apply **custom animations** just like with standard SwiftUI transitions:")
             Code("""
-                .navigationViewStackTransition(
+                .navigationTransition(
                     .fade(.in).animation(
                         .easeInOut(duration: 0.3)
                     )
@@ -71,7 +71,7 @@ struct PageThree: View {
             )
             Text("... and you can even **combine** them too:")
             Code("""
-                .navigationViewStackTransition(
+                .navigationTransition(
                     .slide.combined(with: .fade(.in))
                 )
                 """

--- a/Demo/Demo/RootView.swift
+++ b/Demo/Demo/RootView.swift
@@ -17,7 +17,7 @@ struct RootView: View {
                 .navigationViewStyle(.stack)
             }
         }
-        .navigationViewStackTransition(
+        .navigationTransition(
             appState.transition().animation(appState.animation()),
             interactivity: appState.interactivity()
         )

--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@
 <p align="center">
     <img width="320" src="https://user-images.githubusercontent.com/2538074/199754334-7f2f801d-1d9e-4cc4-a7a0-bb22c9835007.gif">
 </p>
-
 **NavigationTransitions** is a library that integrates seamlessly with SwiftUI's **Navigation** views, allowing complete customization over **push and pop transitions**!
 
 The library is fully compatible with:
 
-- **`NavigationView`** (iOS 13+)
-- **`NavigationStack`** & **`NavigationSplitView`** (iOS 16)
+- **`NavigationView`** (iOS 13, 14, 15)
+- **`NavigationStack`** (iOS 16)
 
 ## Overview
 
-Instead of reinventing entire navigation components in order to customize its transitions, `NavigationTransitions` ships as a simple set of 2 modifiers that can be applied directly to SwiftUI's very own first-party navigation components.
+Instead of reinventing entire navigation components in order to customize its transitions, `NavigationTransitions` ships with a simple modifier that can be applied directly to SwiftUI's very own first-party navigation component.
 
 ### The Basics
 
@@ -28,15 +27,7 @@ NavigationView {
   // ...
 }
 .navigationViewStyle(.stack)
-.navigationViewStackTransition(.slide)
-```
-
-```swift
-NavigationView {
-  // ...
-}
-.navigationViewStyle(.columns)
-.navigationViewColumnTransition(.slide, forColumns: .all)
+.navigationTransition(.slide)
 ```
 
 #### iOS 16
@@ -45,14 +36,7 @@ NavigationView {
 NavigationStack {
   // ...
 }
-.navigationStackTransition(.slide)
-```
-
-```swift
-NavigationSplitView {
-  // ...
-}
-.navigationSplitViewTransition(.slide, forColumns: .all)
+.navigationTransition(.slide)
 ```
 
 ---
@@ -62,7 +46,7 @@ The API is designed to resemble that of built-in SwiftUI Transitions for maximum
 You can apply **custom animations** just like with standard SwiftUI transitions:
 
 ```swift
-.navigationViewStackTransition(
+.navigationTransition(
     .fade(.in).animation(.easeInOut(duration: 0.3))
 )
 ```
@@ -70,7 +54,7 @@ You can apply **custom animations** just like with standard SwiftUI transitions:
 You can **combine** them:
 
 ```swift
-.navigationViewStackTransition(
+.navigationTransition(
     .slide.combined(with: .fade(.in))
 )
 ```
@@ -78,7 +62,7 @@ You can **combine** them:
 And you can **dynamically** choose between transitions based on logic:
 
 ```swift
-.navigationViewStackTransition(
+.navigationTransition(
     reduceMotion ? .fade(.in).animation(.linear) : .slide(.vertical)
 )
 ```
@@ -129,13 +113,13 @@ The [**Demo**](Demo) app showcases some of these transitions in action.
 A sweet additional feature is the ability to override the behavior of the **pop gesture** on the navigation view:
 
 ```swift
-.navigationViewStackTransition(.slide, interactivity: .pan) // full-pan screen gestures!
+.navigationTransition(.slide, interactivity: .pan) // full-pan screen gestures!
 ```
 
 This even works to override its behavior while maintaining the **default system transition** in iOS:
 
 ```swift
-.navigationViewStackTransition(.default, interactivity: .pan) // ✨
+.navigationTransition(.default, interactivity: .pan) // ✨
 ```
 
 ## Documentation

--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -88,7 +88,7 @@ struct NavigationTransitionModifier: ViewModifier {
 
                             OR
 
-                            NavigationStack {
+                            NavigationView {
                                 ...
                             }
                             .navigationViewStyle(.stack)

--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -52,12 +52,7 @@ extension View {
         forColumns columns: NavigationSplitViewColumns,
         interactivity: AnyNavigationTransition.Interactivity = .default
     ) -> some View {
-        self.modifier(
-            NavigationTransitionModifier(
-                transition: transition,
-                interactivity: interactivity
-            )
-        )
+        self.navigationTransition(transition, interactivity: interactivity)
     }
 
     @available(iOS, introduced: 16, deprecated, renamed: "navigationTransition")

--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -24,26 +24,6 @@ public struct NavigationSplitViewColumns: OptionSet {
     }
 }
 
-@available(iOS, introduced: 16, deprecated, message: "Use 'navigationTransition' modifier instead")
-extension UISplitViewControllerColumns {
-    init(_ columns: NavigationSplitViewColumns) {
-        var _columns: Self = []
-        if columns.contains(.sidebar) {
-            _columns.insert(.primary)
-        }
-        if columns.contains(.content) {
-            _columns.insert(.supplementary)
-        }
-        if columns.contains(.detail) {
-            _columns.insert(.secondary)
-        }
-        if columns.contains(.compact) {
-            _columns.insert(.compact)
-        }
-        self = _columns
-    }
-}
-
 extension View {
     @available(iOS, introduced: 16, deprecated, renamed: "navigationTransition")
     @ViewBuilder
@@ -81,11 +61,6 @@ extension View {
 }
 
 struct NavigationTransitionModifier: ViewModifier {
-    enum Target {
-        case navigationSplitView(NavigationSplitViewColumns)
-        case navigationStack
-    }
-
     let transition: AnyNavigationTransition
     let interactivity: AnyNavigationTransition.Interactivity
 
@@ -148,20 +123,6 @@ public struct NavigationViewColumns: OptionSet {
 
     public init(rawValue: Int8) {
         self.rawValue = rawValue
-    }
-}
-
-extension UISplitViewControllerColumns {
-    @available(iOS, introduced: 13, deprecated, message: "Use 'navigationTransition' instead")
-    init(_ columns: NavigationViewColumns) {
-        var _columns: Self = []
-        if columns.contains(.sidebar) {
-            _columns.insert(.primary)
-        }
-        if columns.contains(.detail) {
-            _columns.insert(.secondary)
-        }
-        self = _columns
     }
 }
 

--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -79,8 +79,6 @@ struct NavigationTransitionModifier: ViewModifier {
                         """
                         Modifier "navigationTransition" was applied to a view other than NavigationStack OR NavigationView with .navigationViewStyle(.stack). This has no effect.
 
-                        You could also be attempting to apply the modifier to NavigationSplitView OR NavigationView with .navigationViewStyle(.columns). This also has no effect.
-
                         Please make sure you're applying the modifier correctly:
 
                             NavigationStack {
@@ -95,6 +93,8 @@ struct NavigationTransitionModifier: ViewModifier {
                             }
                             .navigationViewStyle(.stack)
                             .navigationTransition(...)
+
+                        If you're attempting to apply the modifier to NavigationSplitView OR NavigationView with .navigationViewStyle(.columns), this has no effect either. Instead, you should apply the modifier to the child stack navigation component within it (if any).
                         """
                     )
                     return nil

--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -45,7 +45,7 @@ extension UISplitViewControllerColumns {
 }
 
 extension View {
-    @available(iOS, introduced: 16, deprecated, renamed: "navigationTransition", message: "Use 'navigationTransition' instead")
+    @available(iOS, introduced: 16, deprecated, renamed: "navigationTransition")
     @ViewBuilder
     public func navigationSplitViewTransition(
         _ transition: AnyNavigationTransition,
@@ -60,7 +60,7 @@ extension View {
         )
     }
 
-    @available(iOS, introduced: 16, deprecated, renamed: "navigationTransition", message: "Use 'navigationTransition' instead")
+    @available(iOS, introduced: 16, deprecated, renamed: "navigationTransition")
     @ViewBuilder
     public func navigationStackTransition(
         _ transition: AnyNavigationTransition,
@@ -171,7 +171,7 @@ extension UISplitViewControllerColumns {
 }
 
 extension View {
-    @available(iOS, introduced: 13, deprecated, renamed: "navigationTransition", message: "Use 'navigationTransition' instead")
+    @available(iOS, introduced: 13, deprecated, renamed: "navigationTransition")
     @ViewBuilder
     public func navigationViewColumnTransition(
         _ transition: AnyNavigationTransition,
@@ -181,7 +181,7 @@ extension View {
         self.navigationTransition(transition, interactivity: interactivity)
     }
 
-    @available(iOS, introduced: 13, deprecated, renamed: "navigationTransition", message: "Use 'navigationTransition' instead")
+    @available(iOS, introduced: 13, deprecated, renamed: "navigationTransition")
     @ViewBuilder
     public func navigationViewStackTransition(
         _ transition: AnyNavigationTransition,


### PR DESCRIPTION
After some experimentation I came to the conclusion that split view "transitions" are not meant to be modified directly. They're not even a thing in itself, really.

Instead, it should be the stack navigation view *within* the split view that can and should have their transition modified directly.

So I deprecated all the split view modifiers and flattened the 2 stack modifiers into one: `.navigationTransition`. In addition to this, a useful runtime warning will let you know when you're holding it wrong.

This drastically simplifies the API surface to a single entry point and is, I believe, a step in the right direction to easing the entry barrier for this library.