### PR TITLE
Allow `nil` animation

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D5535845290F52F7009E5D72 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5535844290F52F7009E5D72 /* SettingsView.swift */; };
 		D5535847290F5E6F009E5D72 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5535846290F5E6F009E5D72 /* AppState.swift */; };
 		D5755A79291ADC00007F2201 /* Zoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5755A78291ADC00007F2201 /* Zoom.swift */; };
+		D58D46DF29414BCD0013F3FC /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = D58D46DE29414BCD0013F3FC /* SwiftUINavigation */; };
 		D58D803F292176D200D9FEAE /* Flip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58D803E292176D200D9FEAE /* Flip.swift */; };
 		D5AAF4052911C59E009743D3 /* PageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AAF4042911C59E009743D3 /* PageView.swift */; };
 		D5AAF4072911C621009743D3 /* Pages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AAF4062911C621009743D3 /* Pages.swift */; };
@@ -49,6 +50,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D58D46DF29414BCD0013F3FC /* SwiftUINavigation in Frameworks */,
 				D553583F290E97C5009E5D72 /* NavigationTransitions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -137,6 +139,7 @@
 			name = Demo;
 			packageProductDependencies = (
 				D553583E290E97C5009E5D72 /* NavigationTransitions */,
+				D58D46DE29414BCD0013F3FC /* SwiftUINavigation */,
 			);
 			productName = Demo;
 			productReference = D553581B290E9691009E5D72 /* Demo.app */;
@@ -167,6 +170,9 @@
 				Base,
 			);
 			mainGroup = D5535812290E9691009E5D72;
+			packageReferences = (
+				D58D46DD29414BCD0013F3FC /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
+			);
 			productRefGroup = D553581C290E9691009E5D72 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -423,10 +429,26 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		D58D46DD29414BCD0013F3FC /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.3;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		D553583E290E97C5009E5D72 /* NavigationTransitions */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NavigationTransitions;
+		};
+		D58D46DE29414BCD0013F3FC /* SwiftUINavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D58D46DD29414BCD0013F3FC /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
+			productName = SwiftUINavigation;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		D5535845290F52F7009E5D72 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5535844290F52F7009E5D72 /* SettingsView.swift */; };
 		D5535847290F5E6F009E5D72 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5535846290F5E6F009E5D72 /* AppState.swift */; };
 		D5755A79291ADC00007F2201 /* Zoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5755A78291ADC00007F2201 /* Zoom.swift */; };
-		D58D46DF29414BCD0013F3FC /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = D58D46DE29414BCD0013F3FC /* SwiftUINavigation */; };
 		D58D803F292176D200D9FEAE /* Flip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58D803E292176D200D9FEAE /* Flip.swift */; };
 		D5AAF4052911C59E009743D3 /* PageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AAF4042911C59E009743D3 /* PageView.swift */; };
 		D5AAF4072911C621009743D3 /* Pages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AAF4062911C621009743D3 /* Pages.swift */; };
@@ -50,7 +49,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D58D46DF29414BCD0013F3FC /* SwiftUINavigation in Frameworks */,
 				D553583F290E97C5009E5D72 /* NavigationTransitions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -139,7 +137,6 @@
 			name = Demo;
 			packageProductDependencies = (
 				D553583E290E97C5009E5D72 /* NavigationTransitions */,
-				D58D46DE29414BCD0013F3FC /* SwiftUINavigation */,
 			);
 			productName = Demo;
 			productReference = D553581B290E9691009E5D72 /* Demo.app */;
@@ -171,7 +168,6 @@
 			);
 			mainGroup = D5535812290E9691009E5D72;
 			packageReferences = (
-				D58D46DD29414BCD0013F3FC /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
 			);
 			productRefGroup = D553581C290E9691009E5D72 /* Products */;
 			projectDirPath = "";
@@ -429,26 +425,10 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		D58D46DD29414BCD0013F3FC /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.3;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
 		D553583E290E97C5009E5D72 /* NavigationTransitions */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NavigationTransitions;
-		};
-		D58D46DE29414BCD0013F3FC /* SwiftUINavigation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D58D46DD29414BCD0013F3FC /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
-			productName = SwiftUINavigation;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/Demo/AppState.swift
+++ b/Demo/Demo/AppState.swift
@@ -70,63 +70,63 @@ final class AppState: ObservableObject {
         }
     }
 
-    struct Animation {
-        enum Curve: CaseIterable, CustomStringConvertible, Hashable {
-            case linear
-            case easeInOut
-            case spring
+    enum Animation: CaseIterable, CustomStringConvertible, Hashable {
+        case none
+        case linear
+        case easeInOut
+        case spring
 
-            var description: String {
-                switch self {
-                case .linear:
-                    return "Linear"
-                case .easeInOut:
-                    return "Ease In Out"
-                case .spring:
-                    return "Spring"
-                }
+        var description: String {
+            switch self {
+            case .none:
+                return "None"
+            case .linear:
+                return "Linear"
+            case .easeInOut:
+                return "Ease In Out"
+            case .spring:
+                return "Spring"
             }
         }
 
-        enum Duration: CaseIterable, CustomStringConvertible, Hashable {
-            case slow
-            case medium
-            case fast
-
-            var description: String {
-                switch self {
-                case .slow:
-                    return "Slow"
-                case .medium:
-                    return "Medium"
-                case .fast:
-                    return "Fast"
-                }
-            }
-
-            func callAsFunction() -> Double {
-                switch self {
-                case .slow:
-                    return 1
-                case .medium:
-                    return 0.6
-                case .fast:
-                    return 0.35
-                }
-            }
-        }
-
-        var curve: Curve
-        var duration: Duration
-
-        func callAsFunction() -> AnyNavigationTransition.Animation {
-            switch curve {
+        func callAsFunction(duration: Duration) -> AnyNavigationTransition.Animation? {
+            switch self {
+            case .none:
+                return .none
             case .linear:
                 return .linear(duration: duration())
             case .easeInOut:
                 return .easeInOut(duration: duration())
             case .spring:
                 return .interpolatingSpring(stiffness: 120, damping: 50)
+            }
+        }
+    }
+
+    enum Duration: CaseIterable, CustomStringConvertible, Hashable {
+        case slow
+        case medium
+        case fast
+
+        var description: String {
+            switch self {
+            case .slow:
+                return "Slow"
+            case .medium:
+                return "Medium"
+            case .fast:
+                return "Fast"
+            }
+        }
+
+        func callAsFunction() -> Double {
+            switch self {
+            case .slow:
+                return 1
+            case .medium:
+                return 0.6
+            case .fast:
+                return 0.35
             }
         }
     }
@@ -160,7 +160,8 @@ final class AppState: ObservableObject {
     }
 
     @Published var transition: Transition = .slide
-    @Published var animation: Animation = .init(curve: .easeInOut, duration: .fast)
+    @Published var animation: Animation = .easeInOut
+    @Published var duration: Duration = .fast
     @Published var interactivity: Interactivity = .edgePan
 
     @Published var isPresentingSettings: Bool = false

--- a/Demo/Demo/AppState.swift
+++ b/Demo/Demo/AppState.swift
@@ -89,7 +89,11 @@ final class AppState: ObservableObject {
             }
         }
 
-        func callAsFunction(duration: Duration) -> AnyNavigationTransition.Animation? {
+        func callAsFunction(
+            duration: Duration,
+            stiffness: Stiffness,
+            damping: Damping
+        ) -> AnyNavigationTransition.Animation? {
             switch self {
             case .none:
                 return .none
@@ -98,7 +102,7 @@ final class AppState: ObservableObject {
             case .easeInOut:
                 return .easeInOut(duration: duration())
             case .spring:
-                return .interpolatingSpring(stiffness: 120, damping: 50)
+                return .interpolatingSpring(stiffness: stiffness(), damping: damping())
             }
         }
     }
@@ -127,6 +131,67 @@ final class AppState: ObservableObject {
                 return 0.6
             case .fast:
                 return 0.35
+            }
+        }
+    }
+
+    enum Stiffness: CaseIterable, CustomStringConvertible, Hashable {
+        case low
+        case medium
+        case high
+
+        var description: String {
+            switch self {
+            case .low:
+                return "Low"
+            case .medium:
+                return "Medium"
+            case .high:
+                return "High"
+            }
+        }
+
+        func callAsFunction() -> Double {
+            switch self {
+            case .low:
+                return 300
+            case .medium:
+                return 120
+            case .high:
+                return 50
+            }
+        }
+    }
+
+    enum Damping: CaseIterable, CustomStringConvertible, Hashable {
+        case low
+        case medium
+        case high
+        case veryHigh
+
+        var description: String {
+            switch self {
+            case .low:
+                return "Low"
+            case .medium:
+                return "Medium"
+            case .high:
+                return "High"
+            case .veryHigh:
+                return "Very High"
+            }
+        }
+
+        func callAsFunction() -> Double {
+            switch self {
+            case .low:
+                return 20
+            case .medium:
+                return 25
+            case .high:
+                return 30
+            case .veryHigh:
+                return 50
             }
         }
     }
@@ -160,8 +225,12 @@ final class AppState: ObservableObject {
     }
 
     @Published var transition: Transition = .slide
-    @Published var animation: Animation = .easeInOut
+
+    @Published var animation: Animation = .spring
     @Published var duration: Duration = .fast
+    @Published var stiffness: Stiffness = .low
+    @Published var damping: Damping = .high
+
     @Published var interactivity: Interactivity = .edgePan
 
     @Published var isPresentingSettings: Bool = false

--- a/Demo/Demo/RootView.swift
+++ b/Demo/Demo/RootView.swift
@@ -17,12 +17,25 @@ struct RootView: View {
                 .navigationViewStyle(.stack)
             }
         }
-        .navigationTransition(
-            appState.transition().animation(appState.animation(duration: appState.duration)),
-            interactivity: appState.interactivity()
-        )
+        .navigationTransition(transition.animation(animation), interactivity: interactivity)
         .sheet(isPresented: $appState.isPresentingSettings) {
             SettingsView().environmentObject(appState)
         }
+    }
+
+    var transition: AnyNavigationTransition {
+        appState.transition()
+    }
+
+    var animation: AnyNavigationTransition.Animation? {
+        appState.animation(
+            duration: appState.duration,
+            stiffness: appState.stiffness,
+            damping: appState.damping
+        )
+    }
+
+    var interactivity: AnyNavigationTransition.Interactivity {
+        appState.interactivity()
     }
 }

--- a/Demo/Demo/RootView.swift
+++ b/Demo/Demo/RootView.swift
@@ -18,7 +18,7 @@ struct RootView: View {
             }
         }
         .navigationTransition(
-            appState.transition().animation(appState.animation()),
+            appState.transition().animation(appState.animation(duration: appState.duration)),
             interactivity: appState.interactivity()
         )
         .sheet(isPresented: $appState.isPresentingSettings) {

--- a/Demo/Demo/SettingsView.swift
+++ b/Demo/Demo/SettingsView.swift
@@ -8,11 +8,11 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Transition"), footer: transitionFooter) {
+                Section(header: Text("Transition")) {
                     picker("Transition", $appState.transition)
                 }
 
-                Section(header: Text("Animation"), footer: animationFooter) {
+                Section(header: Text("Animation")) {
                     picker("Animation", $appState.animation)
                     switch appState.animation {
                     case .none:
@@ -38,22 +38,6 @@ struct SettingsView: View {
             )
         }
         .navigationViewStyle(.stack)
-    }
-
-    var transitionFooter: some View {
-        Text(
-            """
-            "Swing" is a custom transition exclusive to this demo (only 12 lines of code!).
-            """
-        )
-    }
-
-    var animationFooter: some View {
-        Text(
-            """
-            Note: Duration is ignored when the Spring curve is selected.
-            """
-        )
     }
 
     var interactivityFooter: some View {

--- a/Demo/Demo/SettingsView.swift
+++ b/Demo/Demo/SettingsView.swift
@@ -20,7 +20,8 @@ struct SettingsView: View {
                     case .linear, .easeInOut:
                         picker("Duration", $appState.duration)
                     case .spring:
-                        EmptyView() // TODO: allow customizing dampness
+                        picker("Stiffness", $appState.stiffness)
+                        picker("Damping", $appState.damping)
                     }
                 }
 
@@ -84,8 +85,12 @@ struct SettingsView: View {
 
     func shuffle() {
         appState.transition = .allCases.randomElement()!
+
         appState.animation = .allCases.randomElement()!
         appState.duration = .allCases.randomElement()!
+        appState.stiffness = .allCases.randomElement()!
+        appState.damping = .allCases.randomElement()!
+
         appState.interactivity = .allCases.randomElement()!
     }
 

--- a/Demo/Demo/SettingsView.swift
+++ b/Demo/Demo/SettingsView.swift
@@ -1,5 +1,6 @@
 import NavigationTransitions
 import SwiftUI
+import SwiftUINavigation
 
 struct SettingsView: View {
     @EnvironmentObject var appState: AppState
@@ -12,8 +13,15 @@ struct SettingsView: View {
                 }
 
                 Section(header: Text("Animation"), footer: animationFooter) {
-                    picker("Curve", $appState.animation.curve)
-                    picker("Duration", $appState.animation.duration)
+                    picker("Animation", $appState.animation)
+                    switch appState.animation {
+                    case .none:
+                        EmptyView()
+                    case .linear, .easeInOut:
+                        picker("Duration", $appState.duration)
+                    case .spring:
+                        EmptyView() // TODO: allow customizing dampness
+                    }
                 }
 
                 Section(header: Text("Interactivity"), footer: interactivityFooter) {
@@ -76,8 +84,8 @@ struct SettingsView: View {
 
     func shuffle() {
         appState.transition = .allCases.randomElement()!
-        appState.animation.curve = .allCases.randomElement()!
-        appState.animation.duration = .allCases.randomElement()!
+        appState.animation = .allCases.randomElement()!
+        appState.duration = .allCases.randomElement()!
         appState.interactivity = .allCases.randomElement()!
     }
 

--- a/Demo/Demo/SettingsView.swift
+++ b/Demo/Demo/SettingsView.swift
@@ -1,6 +1,5 @@
 import NavigationTransitions
 import SwiftUI
-import SwiftUINavigation
 
 struct SettingsView: View {
     @EnvironmentObject var appState: AppState

--- a/NavigationTransitions.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NavigationTransitions.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "bb436421f57269fbcfe7360735985321585a86e5",
+          "version": "0.10.1"
+        }
+      },
+      {
         "package": "swift-custom-dump",
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
@@ -17,6 +26,15 @@
           "branch": null,
           "revision": "f2616860a41f9d9932da412a8978fec79c06fe24",
           "version": "0.1.4"
+        }
+      },
+      {
+        "package": "swiftui-navigation",
+        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation.git",
+        "state": {
+          "branch": null,
+          "revision": "a4a84e387c83a735e56d03bf9736d49a07b3c3ae",
+          "version": "0.4.3"
         }
       },
       {

--- a/NavigationTransitions.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NavigationTransitions.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "bb436421f57269fbcfe7360735985321585a86e5",
-          "version": "0.10.1"
-        }
-      },
-      {
         "package": "swift-custom-dump",
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
@@ -26,15 +17,6 @@
           "branch": null,
           "revision": "f2616860a41f9d9932da412a8978fec79c06fe24",
           "version": "0.1.4"
-        }
-      },
-      {
-        "package": "swiftui-navigation",
-        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation.git",
-        "state": {
-          "branch": null,
-          "revision": "a4a84e387c83a735e56d03bf9736d49a07b3c3ae",
-          "version": "0.4.3"
         }
       },
       {

--- a/Sources/NavigationTransition/AnyNavigationTransition.swift
+++ b/Sources/NavigationTransition/AnyNavigationTransition.swift
@@ -22,7 +22,7 @@ public struct AnyNavigationTransition {
 
     @_spi(package)public let isDefault: Bool
     @_spi(package)public let handler: Handler
-    @_spi(package)public var animation: Animation = .default
+    @_spi(package)public var animation: Animation? = .default
 
     public init<T: NavigationTransition>(_ transition: T) {
         self.isDefault = false
@@ -42,7 +42,7 @@ extension AnyNavigationTransition {
     public typealias Animation = _Animation
 
     /// Attaches an animation to this transition.
-    public func animation(_ animation: Animation) -> Self {
+    public func animation(_ animation: Animation?) -> Self {
         var copy = self
         copy.animation = animation
         return copy

--- a/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
+++ b/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
@@ -7,6 +7,7 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
     let transition: AnyNavigationTransition
     weak var baseDelegate: UINavigationControllerDelegate?
     var interactionController: UIPercentDrivenInteractiveTransition?
+    var initialAreAnimationsEnabled = UIView.areAnimationsEnabled
 
     init(transition: AnyNavigationTransition, baseDelegate: UINavigationControllerDelegate?) {
         self.transition = transition
@@ -14,11 +15,14 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
     }
 
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        initialAreAnimationsEnabled = UIView.areAnimationsEnabled
+        UIView.setAnimationsEnabled(transition.animation != nil)
         baseDelegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
     }
 
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         baseDelegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
+        UIView.setAnimationsEnabled(initialAreAnimationsEnabled)
     }
 
     func navigationController(_ navigationController: UINavigationController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
@@ -26,8 +30,15 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
     }
 
     func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationController.Operation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if let operation = NavigationTransitionOperation(operation) {
-            return NavigationTransitionAnimatorProvider(transition: transition, operation: operation)
+        if
+            let animation = transition.animation,
+            let operation = NavigationTransitionOperation(operation)
+        {
+            return NavigationTransitionAnimatorProvider(
+                transition: transition,
+                animation: animation,
+                operation: operation
+            )
         } else {
             return nil
         }
@@ -36,15 +47,17 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
 
 final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnimatedTransitioning {
     let transition: AnyNavigationTransition
+    let animation: Animation
     let operation: NavigationTransitionOperation
 
-    init(transition: AnyNavigationTransition, operation: NavigationTransitionOperation) {
+    init(transition: AnyNavigationTransition, animation: Animation, operation: NavigationTransitionOperation) {
         self.transition = transition
+        self.animation = animation
         self.operation = operation
     }
 
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        transition.animation.duration
+        animation.duration
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
@@ -67,7 +80,7 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
         }
         let animator = UIViewPropertyAnimator(
             duration: transitionDuration(using: transitionContext),
-            timingParameters: transition.animation.timingParameters
+            timingParameters: animation.timingParameters
         )
         cachedAnimators[ObjectIdentifier(transitionContext)] = animator
 

--- a/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
+++ b/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
@@ -5,9 +5,9 @@ import UIKit
 
 final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelegate {
     let transition: AnyNavigationTransition
-    weak var baseDelegate: UINavigationControllerDelegate?
+    private weak var baseDelegate: UINavigationControllerDelegate?
     var interactionController: UIPercentDrivenInteractiveTransition?
-    var initialAreAnimationsEnabled = UIView.areAnimationsEnabled
+    private var initialAreAnimationsEnabled = UIView.areAnimationsEnabled
 
     init(transition: AnyNavigationTransition, baseDelegate: UINavigationControllerDelegate?) {
         self.transition = transition


### PR DESCRIPTION
Additionally:

- Tidy up the demo's settings UI by removing outdated setting screen footers.
- Improve the demo's settings UX by dynamically displaying pickers relevant only to the currently selected animation.