### PR TITLE
Support `.default.animation(.none)`

### DIFF
--- a/Demo/Demo/AppState.swift
+++ b/Demo/Demo/AppState.swift
@@ -229,7 +229,7 @@ final class AppState: ObservableObject {
     @Published var animation: Animation = .spring
     @Published var duration: Duration = .fast
     @Published var stiffness: Stiffness = .low
-    @Published var damping: Damping = .high
+    @Published var damping: Damping = .veryHigh
 
     @Published var interactivity: Interactivity = .edgePan
 

--- a/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
@@ -142,11 +142,7 @@ extension UINavigationController {
             defaultDelegate = delegate
         }
 
-        if transition.isDefault {
-            delegate = defaultDelegate
-        } else {
-            customDelegate = NavigationTransitionDelegate(transition: transition, baseDelegate: defaultDelegate)
-        }
+        customDelegate = NavigationTransitionDelegate(transition: transition, baseDelegate: defaultDelegate)
 
         #if !os(tvOS)
         if defaultPanRecognizer == nil {

--- a/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
+++ b/Sources/NavigationTransitions/NavigationTransitionDelegate.swift
@@ -26,11 +26,16 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
     }
 
     func navigationController(_ navigationController: UINavigationController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return interactionController
+        if !transition.isDefault {
+            return interactionController
+        } else {
+            return nil
+        }
     }
 
     func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationController.Operation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         if
+            !transition.isDefault,
             let animation = transition.animation,
             let operation = NavigationTransitionOperation(operation)
         {


### PR DESCRIPTION
Allows disabling animations when using the `default` transition:

```swift
NavigationStack {
    ...
}
.navigationTransition(.default.animation(.none))
```