### PR TITLE
Back-deploy fix for 96852321

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -323,6 +324,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -361,7 +363,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
-				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -398,7 +399,6 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
-				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};

--- a/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
@@ -135,12 +135,7 @@ extension UINavigationController: RuntimeAssociation {
         _ transition: AnyNavigationTransition,
         interactivity: AnyNavigationTransition.Interactivity = .default
     ) {
-        // fix for https://stackoverflow.com/q/73753796/1922543
-        swizzle(
-            UINavigationController.self,
-            #selector(UINavigationController.popToViewController),
-            #selector(UINavigationController.popToViewController_forceAnimated)
-        )
+        backDeploy96852321()
 
         if defaultDelegate == nil {
             defaultDelegate = delegate
@@ -193,6 +188,24 @@ extension UINavigationController: RuntimeAssociation {
         #endif
     }
 
+    private func backDeploy96852321() {
+        func _swizzle() {
+            swizzle(
+                UINavigationController.self,
+                #selector(UINavigationController.popToViewController),
+                #selector(UINavigationController.popToViewController_forceAnimated)
+            )
+        }
+
+        #if targetEnvironment(macCatalyst)
+        _swizzle()
+        #else
+        if #unavailable(iOS 16.2, tvOS 16.2) {
+            _swizzle()
+        }
+        #endif
+    }
+
     @available(tvOS, unavailable)
     private func exclusivelyEnableGestureRecognizer(_ gestureRecognizer: UIPanGestureRecognizer?) {
         for recognizer in [defaultEdgePanRecognizer!, defaultPanRecognizer!, edgePanRecognizer!, panRecognizer!] {
@@ -207,7 +220,6 @@ extension UINavigationController: RuntimeAssociation {
 
 extension UINavigationController {
     @objc func popToViewController_forceAnimated(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
-        // TODO: `if #unavailable(iOS 17?...)` when fixed by Apple
         popToViewController_forceAnimated(viewController, animated: true)
     }
 }

--- a/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
@@ -223,7 +223,7 @@ extension UINavigationController: RuntimeAssociation {
 }
 
 extension UINavigationController {
-    @objc func popToViewController_forceAnimated(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
+    @objc fileprivate func popToViewController_forceAnimated(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
         popToViewController_forceAnimated(viewController, animated: true)
     }
 }

--- a/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
@@ -189,7 +189,7 @@ extension UINavigationController: RuntimeAssociation {
     }
 
     private func backDeploy96852321() {
-        func _swizzle() {
+        func forceAnimatedPopToViewController() {
             swizzle(
                 UINavigationController.self,
                 #selector(UINavigationController.popToViewController),
@@ -198,10 +198,10 @@ extension UINavigationController: RuntimeAssociation {
         }
 
         #if targetEnvironment(macCatalyst)
-        _swizzle()
+        forceAnimatedPopToViewController()
         #else
         if #unavailable(iOS 16.2, tvOS 16.2) {
-            _swizzle()
+            forceAnimatedPopToViewController()
         }
         #endif
     }

--- a/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
@@ -200,7 +200,7 @@ extension UINavigationController: RuntimeAssociation {
         #if targetEnvironment(macCatalyst)
         forceAnimatedPopToViewController()
         #else
-        if #unavailable(iOS 16.2, tvOS 16.2) {
+        if #available(iOS 16.2, tvOS 16.2, *) {} else {
             forceAnimatedPopToViewController()
         }
         #endif

--- a/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+UIKit.swift
@@ -197,13 +197,17 @@ extension UINavigationController: RuntimeAssociation {
             )
         }
 
-        #if targetEnvironment(macCatalyst)
-        forceAnimatedPopToViewController()
-        #else
-        if #available(iOS 16.2, tvOS 16.2, *) {} else {
+        if #available(iOS 16.2, macCatalyst 16.2, tvOS 16.2, *) {} else {
+            #if targetEnvironment(macCatalyst)
+            let major = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+            let minor = ProcessInfo.processInfo.operatingSystemVersion.minorVersion
+            if (major, minor) < (13, 1) {
+                forceAnimatedPopToViewController()
+            }
+            #else
             forceAnimatedPopToViewController()
+            #endif
         }
-        #endif
     }
 
     @available(tvOS, unavailable)


### PR DESCRIPTION
Related to #41 and #44.

Makes sure to apply the workaround only on affected OSes. On OSes where it's been fixed by Apple (iOS 16.2 and later), standard behaviour will occur instead.