### PR TITLE
Add `@MainActor` annotation to `navigationTransition(:interactivity:)`

### DIFF
--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -2,6 +2,7 @@ import SwiftUI
 @_spi(Advanced) import SwiftUIIntrospect
 
 extension View {
+  @MainActor
 	public func navigationTransition(
 		_ transition: AnyNavigationTransition,
 		interactivity: AnyNavigationTransition.Interactivity = .default

--- a/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
+++ b/Sources/NavigationTransitions/NavigationTransition+SwiftUI.swift
@@ -2,7 +2,7 @@ import SwiftUI
 @_spi(Advanced) import SwiftUIIntrospect
 
 extension View {
-  @MainActor
+	@MainActor
 	public func navigationTransition(
 		_ transition: AnyNavigationTransition,
 		interactivity: AnyNavigationTransition.Interactivity = .default


### PR DESCRIPTION
I believe [the recent release](https://github.com/siteline/swiftui-introspect/releases/tag/1.3.0) of SwiftUI Introspect 1.3.0 breaks SwiftUI Navigation Transition by isolating `introspect(:on:scope:)` to `@MainActor`.