### PR TITLE
Rename navigation transition API

### DIFF
--- a/Examples/Demo/Demo/AppState.swift
+++ b/Examples/Demo/Demo/AppState.swift
@@ -43,7 +43,7 @@ final class AppState: ObservableObject {
 		}
 
 		@MainActor
-		func callAsFunction() -> AnyNavigationTransition {
+		func callAsFunction() -> CustomNavigationTransition {
 			switch self {
 			case .default:
 				.default
@@ -95,7 +95,7 @@ final class AppState: ObservableObject {
 			duration: Duration,
 			stiffness: Stiffness,
 			damping: Damping,
-		) -> AnyNavigationTransition.Animation? {
+		) -> CustomNavigationTransition.Animation? {
 			switch self {
 			case .none:
 				.none
@@ -214,7 +214,7 @@ final class AppState: ObservableObject {
 			}
 		}
 
-		func callAsFunction() -> AnyNavigationTransition.Interactivity {
+		func callAsFunction() -> CustomNavigationTransition.Interactivity {
 			switch self {
 			case .disabled:
 				.disabled

--- a/Examples/Demo/Demo/Custom Transitions/Flip.swift
+++ b/Examples/Demo/Demo/Custom Transitions/Flip.swift
@@ -1,7 +1,7 @@
 import NavigationTransition
 import SwiftUI
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	@MainActor
 	static func flip(axis: Axis) -> Self {
 		.init(Flip(axis: axis))

--- a/Examples/Demo/Demo/Custom Transitions/Swing.swift
+++ b/Examples/Demo/Demo/Custom Transitions/Swing.swift
@@ -1,7 +1,7 @@
 import NavigationTransition
 import SwiftUI
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	@MainActor
 	static var swing: Self {
 		.init(Swing())

--- a/Examples/Demo/Demo/Custom Transitions/Zoom.swift
+++ b/Examples/Demo/Demo/Custom Transitions/Zoom.swift
@@ -1,7 +1,7 @@
 import NavigationTransition
 import SwiftUI
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	@MainActor
 	static var zoom: Self {
 		.init(Zoom())

--- a/Examples/Demo/Demo/Pages.swift
+++ b/Examples/Demo/Demo/Pages.swift
@@ -42,7 +42,7 @@ struct PageTwo: View {
 				NavigationStack {
 				...
 				}
-				.navigationTransition(.slide)
+				.customNavigationTransition(.slide)
 				""",
 			)
 		}
@@ -64,7 +64,7 @@ struct PageThree: View {
 			Text("You can apply **custom animations** just like with standard SwiftUI transitions:")
 			Code(
 				"""
-				.navigationTransition(
+				.customNavigationTransition(
 					.fade(.in).animation(
 						.easeInOut(duration: 0.3)
 					)
@@ -74,7 +74,7 @@ struct PageThree: View {
 			Text("... and you can even **combine** them too:")
 			Code(
 				"""
-				.navigationTransition(
+				.customNavigationTransition(
 					.slide.combined(with: .fade(.in))
 				)
 				""",

--- a/Examples/Demo/Demo/RootView.swift
+++ b/Examples/Demo/Demo/RootView.swift
@@ -17,17 +17,17 @@ struct RootView: View {
 				.navigationViewStyle(.stack)
 			}
 		}
-		.navigationTransition(transition.animation(animation), interactivity: interactivity)
+		.customNavigationTransition(transition.animation(animation), interactivity: interactivity)
 		.sheet(isPresented: $appState.isPresentingSettings) {
 			SettingsView().environmentObject(appState)
 		}
 	}
 
-	var transition: AnyNavigationTransition {
+	var transition: CustomNavigationTransition {
 		appState.transition()
 	}
 
-	var animation: AnyNavigationTransition.Animation? {
+	var animation: CustomNavigationTransition.Animation? {
 		appState.animation(
 			duration: appState.duration,
 			stiffness: appState.stiffness,
@@ -35,7 +35,7 @@ struct RootView: View {
 		)
 	}
 
-	var interactivity: AnyNavigationTransition.Interactivity {
+	var interactivity: CustomNavigationTransition.Interactivity {
 		appState.interactivity()
 	}
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NavigationView {
   // ...
 }
 .navigationViewStyle(.stack)
-.navigationTransition(.slide)
+.customNavigationTransition(.slide)
 ```
 
 #### iOS 16+
@@ -35,7 +35,7 @@ NavigationView {
 NavigationStack {
   // ...
 }
-.navigationTransition(.slide)
+.customNavigationTransition(.slide)
 ```
 
 ---
@@ -45,7 +45,7 @@ The API is designed to resemble that of built-in SwiftUI Transitions for maximum
 You can apply **custom animations** just like with standard SwiftUI transitions:
 
 ```swift
-.navigationTransition(
+.customNavigationTransition(
     .fade(.in).animation(.easeInOut(duration: 0.3))
 )
 ```
@@ -53,7 +53,7 @@ You can apply **custom animations** just like with standard SwiftUI transitions:
 You can **combine** them:
 
 ```swift
-.navigationTransition(
+.customNavigationTransition(
     .slide.combined(with: .fade(.in))
 )
 ```
@@ -61,7 +61,7 @@ You can **combine** them:
 And you can **dynamically** choose between transitions based on logic:
 
 ```swift
-.navigationTransition(
+.customNavigationTransition(
     reduceMotion ? .fade(.in).animation(.linear) : .slide(.vertical)
 )
 ```
@@ -106,13 +106,13 @@ The [**Demo**](Examples/Demo) app showcases some of these transitions in action.
 A sweet additional feature is the ability to override the behavior of the **pop gesture** on the navigation view:
 
 ```swift
-.navigationTransition(.slide, interactivity: .pan) // full-pan screen gestures!
+.customNavigationTransition(.slide, interactivity: .pan) // full-pan screen gestures!
 ```
 
 This even works to override its behavior while maintaining the **default system transition** in iOS:
 
 ```swift
-.navigationTransition(.default, interactivity: .pan) // ✨
+.customNavigationTransition(.default, interactivity: .pan) // ✨
 ```
 
 ## Installation

--- a/Sources/NavigationTransition/Combined.swift
+++ b/Sources/NavigationTransition/Combined.swift
@@ -1,6 +1,6 @@
 import IssueReporting
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	/// Combines this transition with another, returning a new transition that is the result of both transitions
 	/// being applied.
 	@MainActor
@@ -8,14 +8,14 @@ extension AnyNavigationTransition {
 		switch (self.handler, other.handler) {
 		case let (.transient(lhsHandler), .transient(rhsHandler)):
 			struct Erased: NavigationTransitionProtocol {
-				let handler: AnyNavigationTransition.TransientHandler
+				let handler: CustomNavigationTransition.TransientHandler
 
 				@inlinable
 				func transition(from fromView: TransientView, to toView: TransientView, for operation: TransitionOperation, in container: Container) {
 					handler(fromView, toView, operation, container)
 				}
 			}
-			return AnyNavigationTransition(
+			return CustomNavigationTransition(
 				Combined(Erased(handler: lhsHandler), Erased(handler: rhsHandler)),
 			)
 		case (.transient, .primitive),

--- a/Sources/NavigationTransition/CustomNavigationTransition.swift
+++ b/Sources/NavigationTransition/CustomNavigationTransition.swift
@@ -1,7 +1,7 @@
 public import Animation
 package import UIKit
 
-public struct AnyNavigationTransition {
+public struct CustomNavigationTransition {
 	package typealias TransientHandler = @MainActor (
 		AnimatorTransientView,
 		AnimatorTransientView,
@@ -45,7 +45,7 @@ public struct AnyNavigationTransition {
 
 public typealias _Animation = Animation
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	/// Typealias for `Animation`.
 	public typealias Animation = _Animation
 

--- a/Sources/NavigationTransition/Default.swift
+++ b/Sources/NavigationTransition/Default.swift
@@ -1,4 +1,4 @@
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	/// The system-default transition.
 	///
 	/// Use this transition if you wish to modify the interactivity of the transition without altering the
@@ -8,7 +8,7 @@ extension AnyNavigationTransition {
 	///   NavigationStack {
 	///     // ...
 	///   }
-	///   .navigationStackTransition(.default, interactivity: .pan) // enables full-screen panning for system-provided pop
+	///   .customNavigationTransition(.default, interactivity: .pan) // enables full-screen panning for system-provided pop
 	///   ```
 	///
 	/// - Note: The animation for `default` cannot be customized via ``animation(_:)``.

--- a/Sources/NavigationTransition/Deprecations.swift
+++ b/Sources/NavigationTransition/Deprecations.swift
@@ -1,0 +1,2 @@
+@available(*, deprecated, renamed: "CustomNavigationTransition")
+public typealias AnyNavigationTransition = CustomNavigationTransition

--- a/Sources/NavigationTransition/Fade.swift
+++ b/Sources/NavigationTransition/Fade.swift
@@ -1,7 +1,7 @@
 import AtomicTransition
 import UIKit
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	/// A transition that fades the pushed view in, fades the popped view out, or cross-fades both views.
 	@MainActor
 	public static func fade(_ style: Fade.Style) -> Self {

--- a/Sources/NavigationTransition/Slide.swift
+++ b/Sources/NavigationTransition/Slide.swift
@@ -1,7 +1,7 @@
 import AtomicTransition
 public import SwiftUI
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	/// A transition that moves both views in and out along the specified axis.
 	///
 	/// This transition:
@@ -13,7 +13,7 @@ extension AnyNavigationTransition {
 	}
 }
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	/// Equivalent to `slide(axis: .horizontal)`.
 	@MainActor
 	@inlinable

--- a/Sources/SwiftUINavigationTransitions/Deprecations.swift
+++ b/Sources/SwiftUINavigationTransitions/Deprecations.swift
@@ -1,0 +1,14 @@
+public import SwiftUI
+public import UIKitNavigationTransitions
+
+extension View {
+	@MainActor
+	@_disfavoredOverload
+	@available(*, deprecated, renamed: "customNavigationTransition(_:interactivity:)")
+	public func navigationTransition(
+		_ transition: CustomNavigationTransition,
+		interactivity: CustomNavigationTransition.Interactivity = .default,
+	) -> some View {
+		customNavigationTransition(transition, interactivity: interactivity)
+	}
+}

--- a/Sources/SwiftUINavigationTransitions/Documentation.docc/Articles/Custom Transitions.md
+++ b/Sources/SwiftUINavigationTransitions/Documentation.docc/Articles/Custom Transitions.md
@@ -17,14 +17,14 @@ As a first time reader, it is highly recommended that you read **Core Concepts**
 
 ### `NavigationTransitionProtocol`
 
-The main construct the library leverages is called `AnyNavigationTransition`. You may have seen some instances of this type in the README's code samples (e.g. `.slide`).
+The main construct the library leverages is called `CustomNavigationTransition`. You may have seen some instances of this type in the README's code samples (e.g. `.slide`).
 
- `AnyNavigationTransition` instances describe both `push` and `pop` transitions for both *origin* and *destination* views.
+ `CustomNavigationTransition` instances describe both `push` and `pop` transitions for both *origin* and *destination* views.
 
-If we dive into the implementation of `AnyNavigationTransition.slide`, we'll find this:
+If we dive into the implementation of `CustomNavigationTransition.slide`, we'll find this:
 
 ```swift
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
     /// [...]
     public static func slide(axis: Axis) -> Self {
         .init(Slide(axis: axis))
@@ -32,7 +32,7 @@ extension AnyNavigationTransition {
 }
 ```
 
-As you can see, there's not much going on here. The reason is that `AnyNavigationTransition` is actually just a type erasing wrapper around the real meat and potatoes: the protocol `NavigationTransitionProtocol`.
+As you can see, there's not much going on here. The reason is that `CustomNavigationTransition` is actually just a type erasing wrapper around the real meat and potatoes: the protocol `NavigationTransitionProtocol`.
 
 Let's take a look at what (capital "S") `Slide` is:
 
@@ -137,15 +137,15 @@ We'll be covering what these are in just a moment, but as a closing thought befo
 
 ### Basic
 
-#### `AnyNavigationTransition.combined(with:)`
+#### `CustomNavigationTransition.combined(with:)`
 
-You can create a custom `AnyNavigationTransition` by combining two existing transitions:
+You can declare a `CustomNavigationTransition` by combining two existing transitions:
 
 ```swift
 .slide.combined(with: .fade(.in))
 ```
 
-It is rarely the case where you'd want to combine `AnyNavigationTransition`s in this manner due to their nature as high level abstractions. In fact, most of the time they won't combine very well at all, and will produce glitchy or weird effects. This is because two or more fully-fledged transitions tend to override the same view properties with different values, producing unexpected outcomes.
+It is rarely the case where you'd want to combine `CustomNavigationTransition`s in this manner due to their nature as high level abstractions. In fact, most of the time they won't combine very well at all, and will produce glitchy or weird effects. This is because two or more fully-fledged transitions tend to override the same view properties with different values, producing unexpected outcomes.
 
 Instead, most combinations should happen at lowers level, in `NavigationTransitionProtocol` and `AtomicTransition` conformances.
 

--- a/Sources/SwiftUINavigationTransitions/SwiftUISupport.swift
+++ b/Sources/SwiftUINavigationTransitions/SwiftUISupport.swift
@@ -1,12 +1,12 @@
-public import UIKitNavigationTransitions
 public import SwiftUI
+public import UIKitNavigationTransitions
 @_spi(Advanced) import SwiftUIIntrospect
 
 extension View {
 	@MainActor
-	public func navigationTransition(
-		_ transition: AnyNavigationTransition,
-		interactivity: AnyNavigationTransition.Interactivity = .default,
+	public func customNavigationTransition(
+		_ transition: CustomNavigationTransition,
+		interactivity: CustomNavigationTransition.Interactivity = .default,
 	) -> some View {
 		self.introspect(
 			.navigationView(style: .stack),

--- a/Sources/UIKitNavigationTransitions/Delegate.swift
+++ b/Sources/UIKitNavigationTransitions/Delegate.swift
@@ -4,11 +4,11 @@ import NavigationTransition
 import UIKit
 
 final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelegate {
-	var transition: AnyNavigationTransition
+	var transition: CustomNavigationTransition
 	private weak var baseDelegate: (any UINavigationControllerDelegate)? = nil
 	var interactionController: UIPercentDrivenInteractiveTransition? = nil
 
-	init(transition: AnyNavigationTransition, baseDelegate: (any UINavigationControllerDelegate)?) {
+	init(transition: CustomNavigationTransition, baseDelegate: (any UINavigationControllerDelegate)?) {
 		self.transition = transition
 		self.baseDelegate = baseDelegate
 	}
@@ -47,11 +47,11 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
 }
 
 final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnimatedTransitioning {
-	let transition: AnyNavigationTransition
+	let transition: CustomNavigationTransition
 	let animation: Animation
 	let operation: NavigationTransitionOperation
 
-	init(transition: AnyNavigationTransition, animation: Animation, operation: NavigationTransitionOperation) {
+	init(transition: CustomNavigationTransition, animation: Animation, operation: NavigationTransitionOperation) {
 		self.transition = transition
 		self.animation = animation
 		self.operation = operation
@@ -141,7 +141,7 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
 	}
 
 	private func transientViews(
-		for handler: AnyNavigationTransition.TransientHandler,
+		for handler: CustomNavigationTransition.TransientHandler,
 		animator: any Animator,
 		context: (container: UIView, fromUIView: UIView, toUIView: UIView),
 	) -> (fromView: AnimatorTransientView, toView: AnimatorTransientView)? {

--- a/Sources/UIKitNavigationTransitions/Interactivity.swift
+++ b/Sources/UIKitNavigationTransitions/Interactivity.swift
@@ -1,6 +1,6 @@
 public import NavigationTransition
 
-extension AnyNavigationTransition {
+extension CustomNavigationTransition {
 	public enum Interactivity {
 		case disabled
 		case edgePan

--- a/Sources/UIKitNavigationTransitions/UIKitSupport.swift
+++ b/Sources/UIKitNavigationTransitions/UIKitSupport.swift
@@ -22,9 +22,9 @@ public struct UISplitViewControllerColumns: OptionSet, Sendable {
 
 extension UISplitViewController {
 	public func setNavigationTransition(
-		_ transition: AnyNavigationTransition,
+		_ transition: CustomNavigationTransition,
 		forColumns columns: UISplitViewControllerColumns,
-		interactivity: AnyNavigationTransition.Interactivity = .default,
+		interactivity: CustomNavigationTransition.Interactivity = .default,
 	) {
 		if columns.contains(.compact), let compact = compactViewController as? UINavigationController {
 			compact.setNavigationTransition(transition, interactivity: interactivity)
@@ -117,8 +117,8 @@ extension UINavigationController {
 	}
 
 	public func setNavigationTransition(
-		_ transition: AnyNavigationTransition,
-		interactivity: AnyNavigationTransition.Interactivity = .default,
+		_ transition: CustomNavigationTransition,
+		interactivity: CustomNavigationTransition.Interactivity = .default,
 	) {
 		do {
 			try UINavigationController.swizzle()


### PR DESCRIPTION
## Summary
- Rename the erased transition type to `CustomNavigationTransition`
- Rename the SwiftUI modifier to `customNavigationTransition(_:interactivity:)`
- Add deprecated forwarding APIs for the old type and modifier names
- Update README, DocC, and demo references

Fixes #172 