### PR TITLE
Update Swift 6.2 CI and formatting configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   apple:
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]')
     name: ${{ matrix.platform }} (Swift ${{ matrix.swift }})
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -45,11 +45,6 @@ jobs:
         swift:
           - "6.2"
           - "6.3"
-        include:
-          - swift: "6.2"
-            runner: macos-26
-          - swift: "6.3"
-            runner: macos-26
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5

--- a/.swiftformat
+++ b/.swiftformat
@@ -8,7 +8,7 @@
 --extensionacl on-declarations
 --trailing-commas always
 --nil-init insert
---import-grouping testable-last
+--import-grouping alpha
 --wrap-conditions before-first
 --guard-else next-line
 
@@ -21,6 +21,7 @@
 --disable redundantRawValues
 --disable redundantSelf
 --disable redundantStaticSelf
+--disable redundantSwiftTestingSuite
 --disable redundantType
 --disable redundantTypedThrows
 --disable redundantViewBuilder


### PR DESCRIPTION
## Summary

- simplify the Apple CI runner configuration for the Swift 6.2 and Swift 6.3 matrix
- align SwiftFormat rules with the current project conventions