### PR TITLE
Adopt native content pop gestures on OS 26

### DIFF
--- a/Examples/Demo/Demo/AppState.swift
+++ b/Examples/Demo/Demo/AppState.swift
@@ -201,7 +201,7 @@ final class AppState: ObservableObject {
 	enum Interactivity: CaseIterable, CustomStringConvertible, Hashable {
 		case disabled
 		case edgePan
-		case pan
+		case contentPan
 
 		var description: String {
 			switch self {
@@ -209,8 +209,8 @@ final class AppState: ObservableObject {
 				"Disabled"
 			case .edgePan:
 				"Edge Pan"
-			case .pan:
-				"Pan"
+			case .contentPan:
+				"Content Pan"
 			}
 		}
 
@@ -220,8 +220,8 @@ final class AppState: ObservableObject {
 				.disabled
 			case .edgePan:
 				.edgePan
-			case .pan:
-				.pan
+			case .contentPan:
+				.contentPan
 			}
 		}
 	}
@@ -233,7 +233,7 @@ final class AppState: ObservableObject {
 	@Published var stiffness: Stiffness = .low
 	@Published var damping: Damping = .veryHigh
 
-	@Published var interactivity: Interactivity = .edgePan
+	@Published var interactivity: Interactivity = .contentPan
 
 	@Published var isPresentingSettings: Bool = false
 }

--- a/Examples/Demo/Demo/SettingsView.swift
+++ b/Examples/Demo/Demo/SettingsView.swift
@@ -46,7 +46,7 @@ struct SettingsView: View {
 
 			• Disabled.
 			• Edge Pan: recognized from the edge of the screen only.
-			• Pan: recognized anywhere on the screen! ✨
+			• Content Pan: recognized anywhere on the screen.
 			""",
 		)
 	}

--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,9 @@ let package = Package(
 			.product(name: "ObjCRuntimeTools", package: "objc-runtime-tools"),
 			.product(name: "Once", package: "swift-once-macro"),
 		]),
+		.testTarget(name: "UIKitNavigationTransitionsTests", dependencies: [
+			"UIKitNavigationTransitions",
+		]),
 
 		.target(name: "SwiftUINavigationTransitions", dependencies: [
 			"UIKitNavigationTransitions",

--- a/README.md
+++ b/README.md
@@ -104,16 +104,22 @@ The [**Demo**](Examples/Demo) app showcases some of these transitions in action.
 
 ### Interactivity
 
-A sweet additional feature is the ability to override the behavior of the **pop gesture** on the navigation view:
+Choose from three interactivity options: `.disabled`, `.edgePan`, or `.contentPan`:
 
 ```swift
-.customNavigationTransition(.slide, interactivity: .pan) // full-pan screen gestures!
+.customNavigationTransition(.slide, interactivity: .disabled) // disables back swipes
 ```
 
-This even works to override its behavior while maintaining the **default system transition** in iOS:
+`.contentPan` back-deploys iOS 26 full-screen **pop gestures** all the way to iOS 13:
 
 ```swift
-.customNavigationTransition(.default, interactivity: .pan) // ✨
+.customNavigationTransition(.slide, interactivity: .contentPan) // works on iOS 13-26!
+```
+
+This also works while maintaining the **default system transition**:
+
+```swift
+.customNavigationTransition(.default, interactivity: .contentPan) // works on iOS 13-26!
 ```
 
 ## Installation

--- a/Sources/NavigationTransition/Default.swift
+++ b/Sources/NavigationTransition/Default.swift
@@ -8,7 +8,7 @@ extension CustomNavigationTransition {
 	///   NavigationStack {
 	///     // ...
 	///   }
-	///   .customNavigationTransition(.default, interactivity: .pan) // enables full-screen panning for system-provided pop
+	///   .customNavigationTransition(.default, interactivity: .disabled) // disables swipe back gesture
 	///   ```
 	///
 	/// - Note: The animation for `default` cannot be customized via ``animation(_:)``.

--- a/Sources/UIKitNavigationTransitions/Interactivity.swift
+++ b/Sources/UIKitNavigationTransitions/Interactivity.swift
@@ -2,13 +2,33 @@ public import NavigationTransition
 
 extension CustomNavigationTransition {
 	public enum Interactivity {
+		/// Disables interactive pop gestures.
 		case disabled
+		/// Recognizes interactive pop gestures from the leading screen edge.
 		case edgePan
-		case pan
+		/// Recognizes interactive pop gestures across the content area on every supported iOS and Mac Catalyst version.
+		case contentPan
 
+		@available(*, deprecated, renamed: "contentPan")
+		@inlinable
+		public static var pan: Self {
+			.contentPan
+		}
+
+		/// The default interactivity for the current platform version.
+		///
+		/// This is ``contentPan`` on iOS and Mac Catalyst 26 and later, and ``edgePan`` on earlier versions.
 		@inlinable
 		public static var `default`: Self {
+			#if os(iOS)
+			if #available(iOS 26, macCatalyst 26, *) {
+				.contentPan
+			} else {
+				.edgePan
+			}
+			#else
 			.edgePan
+			#endif
 		}
 	}
 }

--- a/Sources/UIKitNavigationTransitions/UIKitSupport.swift
+++ b/Sources/UIKitNavigationTransitions/UIKitSupport.swift
@@ -137,15 +137,17 @@ extension UINavigationController {
 		}
 
 		#if !os(tvOS) && !os(visionOS)
-		if defaultEdgePanRecognizer.strongDelegate == nil {
-			defaultEdgePanRecognizer.strongDelegate = NavigationGestureRecognizerDelegate(controller: self)
-		}
+		if #unavailable(iOS 26, macCatalyst 26) {
+			if defaultEdgePanRecognizer.strongDelegate == nil {
+				defaultEdgePanRecognizer.strongDelegate = NavigationGestureRecognizerDelegate(controller: self)
+			}
 
-		if defaultPanRecognizer == nil {
-			defaultPanRecognizer = UIPanGestureRecognizer()
-			defaultPanRecognizer.targets = defaultEdgePanRecognizer.targets // https://stackoverflow.com/a/60526328/1922543
-			defaultPanRecognizer.strongDelegate = NavigationGestureRecognizerDelegate(controller: self)
-			view.addGestureRecognizer(defaultPanRecognizer)
+			if defaultPanRecognizer == nil {
+				defaultPanRecognizer = UIPanGestureRecognizer()
+				defaultPanRecognizer.targets = defaultEdgePanRecognizer.targets // https://stackoverflow.com/a/60526328/1922543
+				defaultPanRecognizer.strongDelegate = NavigationGestureRecognizerDelegate(controller: self)
+				view.addGestureRecognizer(defaultPanRecognizer)
+			}
 		}
 
 		if edgePanRecognizer == nil {
@@ -166,20 +168,27 @@ extension UINavigationController {
 		if transition.isDefault {
 			switch interactivity {
 			case .disabled:
-				exclusivelyEnableGestureRecognizer(.none)
+				exclusivelyEnableGestureRecognizers([])
 			case .edgePan:
-				exclusivelyEnableGestureRecognizer(defaultEdgePanRecognizer)
-			case .pan:
-				exclusivelyEnableGestureRecognizer(defaultPanRecognizer)
+				exclusivelyEnableGestureRecognizers([defaultEdgePanRecognizer])
+			case .contentPan:
+				if #available(iOS 26, macCatalyst 26, *) {
+					exclusivelyEnableGestureRecognizers([
+						defaultEdgePanRecognizer,
+						interactiveContentPopGestureRecognizer,
+					].compactMap { $0 })
+				} else {
+					exclusivelyEnableGestureRecognizers([defaultPanRecognizer])
+				}
 			}
 		} else {
 			switch interactivity {
 			case .disabled:
-				exclusivelyEnableGestureRecognizer(.none)
+				exclusivelyEnableGestureRecognizers([])
 			case .edgePan:
-				exclusivelyEnableGestureRecognizer(edgePanRecognizer)
-			case .pan:
-				exclusivelyEnableGestureRecognizer(panRecognizer)
+				exclusivelyEnableGestureRecognizers([edgePanRecognizer])
+			case .contentPan:
+				exclusivelyEnableGestureRecognizers([panRecognizer])
 			}
 		}
 		#endif
@@ -249,13 +258,22 @@ extension UINavigationController {
 
 	@available(tvOS, unavailable)
 	@available(visionOS, unavailable)
-	private func exclusivelyEnableGestureRecognizer(_ gestureRecognizer: UIPanGestureRecognizer?) {
-		for recognizer in [defaultEdgePanRecognizer!, defaultPanRecognizer!, edgePanRecognizer!, panRecognizer!] {
-			if let gestureRecognizer, recognizer === gestureRecognizer {
-				recognizer.isEnabled = true
-			} else {
-				recognizer.isEnabled = false
+	private func exclusivelyEnableGestureRecognizers(_ enabledGestureRecognizers: [UIGestureRecognizer]) {
+		var gestureRecognizers: [UIGestureRecognizer] = [
+			defaultEdgePanRecognizer,
+			defaultPanRecognizer,
+			edgePanRecognizer,
+			panRecognizer,
+		].compactMap { $0 }
+
+		if #available(iOS 26, macCatalyst 26, *) {
+			if let interactiveContentPopGestureRecognizer {
+				gestureRecognizers.append(interactiveContentPopGestureRecognizer)
 			}
+		}
+
+		for gestureRecognizer in gestureRecognizers {
+			gestureRecognizer.isEnabled = enabledGestureRecognizers.contains { gestureRecognizer === $0 }
 		}
 	}
 }

--- a/Tests/TestPlans/SwiftUINavigationTransitions.xctestplan
+++ b/Tests/TestPlans/SwiftUINavigationTransitions.xctestplan
@@ -26,6 +26,13 @@
         "identifier" : "AtomicTransitionTests",
         "name" : "AtomicTransitionTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "UIKitNavigationTransitionsTests",
+        "name" : "UIKitNavigationTransitionsTests"
+      }
     }
   ],
   "version" : 1

--- a/Tests/UIKitNavigationTransitionsTests/GestureRecognizerTests.swift
+++ b/Tests/UIKitNavigationTransitionsTests/GestureRecognizerTests.swift
@@ -1,0 +1,87 @@
+#if !os(tvOS) && !os(visionOS)
+import Testing
+import UIKit
+@testable import UIKitNavigationTransitions
+
+@MainActor
+struct GestureRecognizerTests {
+	@available(iOS 26, macCatalyst 26, *)
+	@Test
+	func defaultInteractivityUsesSystemRecognizer() throws {
+		let navigationController = makeNavigationController()
+
+		navigationController.setNavigationTransition(.default)
+
+		let contentPopGestureRecognizer = try #require(
+			navigationController.interactiveContentPopGestureRecognizer
+		)
+
+		#expect(navigationController.defaultEdgePanRecognizer.isEnabled)
+		#expect(contentPopGestureRecognizer.isEnabled)
+		#expect(navigationController.defaultPanRecognizer == nil)
+		#expect(!navigationController.edgePanRecognizer.isEnabled)
+		#expect(!navigationController.panRecognizer.isEnabled)
+	}
+
+	@available(iOS 26, macCatalyst 26, *)
+	@Test
+	func defaultEdgePanDisablesContentRecognizer() throws {
+		let navigationController = makeNavigationController()
+
+		navigationController.setNavigationTransition(.default, interactivity: .edgePan)
+
+		let contentPopGestureRecognizer = try #require(
+			navigationController.interactiveContentPopGestureRecognizer
+		)
+
+		#expect(navigationController.defaultEdgePanRecognizer.isEnabled)
+		#expect(!contentPopGestureRecognizer.isEnabled)
+		#expect(!navigationController.edgePanRecognizer.isEnabled)
+		#expect(!navigationController.panRecognizer.isEnabled)
+	}
+
+	@available(iOS 26, macCatalyst 26, *)
+	@Test
+	func disabledInteractivityDisablesSystemRecognizers() throws {
+		let navigationController = makeNavigationController()
+
+		navigationController.setNavigationTransition(.default, interactivity: .disabled)
+
+		let contentPopGestureRecognizer = try #require(
+			navigationController.interactiveContentPopGestureRecognizer
+		)
+
+		#expect(!navigationController.defaultEdgePanRecognizer.isEnabled)
+		#expect(!contentPopGestureRecognizer.isEnabled)
+		#expect(!navigationController.edgePanRecognizer.isEnabled)
+		#expect(!navigationController.panRecognizer.isEnabled)
+	}
+
+	@available(iOS 26, macCatalyst 26, *)
+	@Test
+	func customContentPanUsesCustomRecognizer() throws {
+		let navigationController = makeNavigationController()
+
+		navigationController.setNavigationTransition(.slide, interactivity: .contentPan)
+
+		let contentPopGestureRecognizer = try #require(
+			navigationController.interactiveContentPopGestureRecognizer
+		)
+
+		#expect(!navigationController.defaultEdgePanRecognizer.isEnabled)
+		#expect(!contentPopGestureRecognizer.isEnabled)
+		#expect(!navigationController.edgePanRecognizer.isEnabled)
+		#expect(navigationController.panRecognizer.isEnabled)
+	}
+
+	private func makeNavigationController() -> UINavigationController {
+		let navigationController = UINavigationController()
+		navigationController.setViewControllers(
+			[UIViewController(), UIViewController()],
+			animated: false,
+		)
+		navigationController.loadViewIfNeeded()
+		return navigationController
+	}
+}
+#endif


### PR DESCRIPTION
## Summary

- use UIKit's native content pop recognizer for default transitions on iOS and Mac Catalyst 26+
- rename the full-screen interactivity mode to `contentPan`, retain `pan` as a deprecated spelling, and make the default OS-aware
- document the three interactivity modes and add recognizer-selection coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Content Pan** interactivity option for full-screen pop gestures.
  * Updated default gesture behavior for iOS 26 and later.
  * Retained the previous **Pan** option as a deprecated alias.

* **Documentation**
  * Updated settings descriptions, README guidance, and transition examples to cover disabled, edge pan, and content pan options.

* **Tests**
  * Added coverage for gesture recognizer behavior across supported interactivity modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->