### PR TITLE
chore: enforce SwiftFormat configuration

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,14 +5,24 @@
 --indent tab
 --tabwidth 2
 --maxwidth 120
+--allow-partial-wrapping false
 --ifdef no-indent
 --ranges preserve
 --extensionacl on-declarations
 --trailing-commas always
 --nil-init insert
 --import-grouping alpha
+--wrap-arguments before-first
 --wrap-conditions before-first
+--wrap-parameters before-first
+--wrap-return-type never
+--wrap-string-interpolation true
 --guard-else next-line
+
+# Opt-in rules
+--enable blockComments
+--enable wrapMultilineConditionalAssignment
+--enable wrapMultilineFunctionChains
 
 # Disabled rules
 --disable blankLinesAroundMark

--- a/.swiftformat
+++ b/.swiftformat
@@ -4,6 +4,7 @@
 --header ignore
 --indent tab
 --maxwidth 120
+--tabwidth 2
 --ifdef no-indent
 --ranges preserve
 --extensionacl on-declarations

--- a/.swiftformat
+++ b/.swiftformat
@@ -3,6 +3,7 @@
 
 --header ignore
 --indent tab
+--maxwidth 120
 --ifdef no-indent
 --ranges preserve
 --extensionacl on-declarations

--- a/.swiftformat
+++ b/.swiftformat
@@ -5,7 +5,6 @@
 --indent tab
 --tabwidth 2
 --maxwidth 120
---allow-partial-wrapping false
 --ifdef no-indent
 --ranges preserve
 --extensionacl on-declarations
@@ -16,7 +15,6 @@
 --wrap-conditions before-first
 --wrap-parameters before-first
 --wrap-return-type never
---wrap-string-interpolation true
 --guard-else next-line
 
 # Opt-in rules

--- a/.swiftformat
+++ b/.swiftformat
@@ -3,8 +3,8 @@
 
 --header ignore
 --indent tab
---maxwidth 120
 --tabwidth 2
+--maxwidth 120
 --ifdef no-indent
 --ranges preserve
 --extensionacl on-declarations

--- a/Examples/Demo/Demo/Pages.swift
+++ b/Examples/Demo/Demo/Pages.swift
@@ -3,7 +3,9 @@ import SwiftUI
 struct PageOne: View {
 	var body: some View {
 		let content = Group {
-			Text("**SwiftUINavigationTransitions** is a library that integrates seamlessly with SwiftUI's **Navigation** views, allowing complete customization over **push and pop transitions**!")
+			Text(
+				"**SwiftUINavigationTransitions** is a library that integrates seamlessly with SwiftUI's **Navigation** views, allowing complete customization over **push and pop transitions**!",
+			)
 		}
 
 		PageView(number: 1, title: "Welcome", color: .orange) {
@@ -35,7 +37,9 @@ struct PageOne: View {
 struct PageTwo: View {
 	var body: some View {
 		let content = Group {
-			Text("The library is fully compatible with **NavigationView** in iOS 13+, and the new **NavigationStack** in iOS 16.")
+			Text(
+				"The library is fully compatible with **NavigationView** in iOS 13+, and the new **NavigationStack** in iOS 16.",
+			)
 			Text("In fact, that entire transition you just saw can be implemented in **one line** of SwiftUI code:")
 			Code(
 				"""
@@ -60,7 +64,9 @@ struct PageTwo: View {
 struct PageThree: View {
 	var body: some View {
 		let content = Group {
-			Text("The API is designed to resemble that of built-in SwiftUI Transitions for maximum **familiarity** and **ease of use**.")
+			Text(
+				"The API is designed to resemble that of built-in SwiftUI Transitions for maximum **familiarity** and **ease of use**.",
+			)
 			Text("You can apply **custom animations** just like with standard SwiftUI transitions:")
 			Code(
 				"""
@@ -94,7 +100,9 @@ struct PageThree: View {
 struct PageFour: View {
 	var body: some View {
 		let content = Group {
-			Text("The library ships with some standard transitions out of the box, however you can create fully **custom transitions** in just a few lines of code.")
+			Text(
+				"The library ships with some standard transitions out of the box, however you can create fully **custom transitions** in just a few lines of code.",
+			)
 			Text("This demo features some presets to play with. You'll find them in the **settings** menu at the top.")
 		}
 
@@ -111,8 +119,12 @@ struct PageFour: View {
 struct PageFive: View {
 	var body: some View {
 		let content = Group {
-			Text("The repository contains extensive [documentation](https://github.com/davdroman/swiftui-navigation-transitions/tree/main/Documentation) from how to get started to going fully custom, depending on your needs. 📖")
-			Text("Feel free to **post questions**, **ideas**, or any **cool transitions** you build in the [Discussions](https://github.com/davdroman/swiftui-navigation-transitions/discussions) section! 💬")
+			Text(
+				"The repository contains extensive [documentation](https://github.com/davdroman/swiftui-navigation-transitions/tree/main/Documentation) from how to get started to going fully custom, depending on your needs. 📖",
+			)
+			Text(
+				"Feel free to **post questions**, **ideas**, or any **cool transitions** you build in the [Discussions](https://github.com/davdroman/swiftui-navigation-transitions/discussions) section! 💬",
+			)
 			Text("I sincerely hope you enjoy using this library as much as I enjoyed building it.")
 			Text("❤️")
 		}

--- a/Examples/Demo/Demo/Pages.swift
+++ b/Examples/Demo/Demo/Pages.swift
@@ -5,8 +5,8 @@ struct PageOne: View {
 		let content = Group {
 			Text(
 				"""
-				**SwiftUINavigationTransitions** is a library that integrates seamlessly with \
-				SwiftUI's **Navigation** views, allowing complete customization over **push and pop transitions**!
+				**SwiftUINavigationTransitions** is a library that integrates seamlessly with SwiftUI's **Navigation** views, \
+				allowing complete customization over **push and pop transitions**!
 				""",
 			)
 		}
@@ -41,10 +41,7 @@ struct PageTwo: View {
 	var body: some View {
 		let content = Group {
 			Text(
-				"""
-				The library is fully compatible with **NavigationView** in iOS 13+, and the new \
-				**NavigationStack** in iOS 16.
-				""",
+				"The library is fully compatible with **NavigationView** in iOS 13+, and the new **NavigationStack** in iOS 16.",
 			)
 			Text("In fact, that entire transition you just saw can be implemented in **one line** of SwiftUI code:")
 			Code(
@@ -72,8 +69,8 @@ struct PageThree: View {
 		let content = Group {
 			Text(
 				"""
-				The API is designed to resemble that of built-in SwiftUI Transitions for maximum \
-				**familiarity** and **ease of use**.
+				The API is designed to resemble that of built-in SwiftUI Transitions for maximum **familiarity** and **ease of \
+				use**.
 				""",
 			)
 			Text("You can apply **custom animations** just like with standard SwiftUI transitions:")
@@ -111,8 +108,8 @@ struct PageFour: View {
 		let content = Group {
 			Text(
 				"""
-				The library ships with some standard transitions out of the box, however you can \
-				create fully **custom transitions** in just a few lines of code.
+				The library ships with some standard transitions out of the box, however you can create fully **custom \
+				transitions** in just a few lines of code.
 				""",
 			)
 			Text("This demo features some presets to play with. You'll find them in the **settings** menu at the top.")
@@ -133,16 +130,15 @@ struct PageFive: View {
 		let content = Group {
 			Text(
 				"""
-				The repository contains extensive [documentation](https://github.com/davdroman/\
-				swiftui-navigation-transitions/tree/main/Documentation) from how to get started to \
-				going fully custom, depending on your needs. 📖
+				The repository contains extensive \
+				[documentation](https://github.com/davdroman/swiftui-navigation-transitions/tree/main/Documentation) from how \
+				to get started to going fully custom, depending on your needs. 📖
 				""",
 			)
 			Text(
 				"""
 				Feel free to **post questions**, **ideas**, or any **cool transitions** you build in the \
-				[Discussions](https://github.com/davdroman/swiftui-navigation-transitions/discussions) \
-				section! 💬
+				[Discussions](https://github.com/davdroman/swiftui-navigation-transitions/discussions) section! 💬
 				""",
 			)
 			Text("I sincerely hope you enjoy using this library as much as I enjoyed building it.")

--- a/Examples/Demo/Demo/Pages.swift
+++ b/Examples/Demo/Demo/Pages.swift
@@ -4,7 +4,10 @@ struct PageOne: View {
 	var body: some View {
 		let content = Group {
 			Text(
-				"**SwiftUINavigationTransitions** is a library that integrates seamlessly with SwiftUI's **Navigation** views, allowing complete customization over **push and pop transitions**!",
+				"""
+				**SwiftUINavigationTransitions** is a library that integrates seamlessly with \
+				SwiftUI's **Navigation** views, allowing complete customization over **push and pop transitions**!
+				""",
 			)
 		}
 
@@ -38,7 +41,10 @@ struct PageTwo: View {
 	var body: some View {
 		let content = Group {
 			Text(
-				"The library is fully compatible with **NavigationView** in iOS 13+, and the new **NavigationStack** in iOS 16.",
+				"""
+				The library is fully compatible with **NavigationView** in iOS 13+, and the new \
+				**NavigationStack** in iOS 16.
+				""",
 			)
 			Text("In fact, that entire transition you just saw can be implemented in **one line** of SwiftUI code:")
 			Code(
@@ -65,7 +71,10 @@ struct PageThree: View {
 	var body: some View {
 		let content = Group {
 			Text(
-				"The API is designed to resemble that of built-in SwiftUI Transitions for maximum **familiarity** and **ease of use**.",
+				"""
+				The API is designed to resemble that of built-in SwiftUI Transitions for maximum \
+				**familiarity** and **ease of use**.
+				""",
 			)
 			Text("You can apply **custom animations** just like with standard SwiftUI transitions:")
 			Code(
@@ -101,7 +110,10 @@ struct PageFour: View {
 	var body: some View {
 		let content = Group {
 			Text(
-				"The library ships with some standard transitions out of the box, however you can create fully **custom transitions** in just a few lines of code.",
+				"""
+				The library ships with some standard transitions out of the box, however you can \
+				create fully **custom transitions** in just a few lines of code.
+				""",
 			)
 			Text("This demo features some presets to play with. You'll find them in the **settings** menu at the top.")
 		}
@@ -120,10 +132,18 @@ struct PageFive: View {
 	var body: some View {
 		let content = Group {
 			Text(
-				"The repository contains extensive [documentation](https://github.com/davdroman/swiftui-navigation-transitions/tree/main/Documentation) from how to get started to going fully custom, depending on your needs. 📖",
+				"""
+				The repository contains extensive [documentation](https://github.com/davdroman/\
+				swiftui-navigation-transitions/tree/main/Documentation) from how to get started to \
+				going fully custom, depending on your needs. 📖
+				""",
 			)
 			Text(
-				"Feel free to **post questions**, **ideas**, or any **cool transitions** you build in the [Discussions](https://github.com/davdroman/swiftui-navigation-transitions/discussions) section! 💬",
+				"""
+				Feel free to **post questions**, **ideas**, or any **cool transitions** you build in the \
+				[Discussions](https://github.com/davdroman/swiftui-navigation-transitions/discussions) \
+				section! 💬
+				""",
 			)
 			Text("I sincerely hope you enjoy using this library as much as I enjoyed building it.")
 			Text("❤️")

--- a/Sources/AtomicTransition/AtomicTransitionBuilder.swift
+++ b/Sources/AtomicTransition/AtomicTransitionBuilder.swift
@@ -8,7 +8,9 @@ public enum AtomicTransitionBuilder {
 		first
 	}
 
-	public static func buildPartialBlock<T1: AtomicTransition, T2: AtomicTransition>(accumulated: T1, next: T2) -> Combined<T1, T2> {
+	public static func buildPartialBlock<T1: AtomicTransition, T2: AtomicTransition>(accumulated: T1,
+	                                                                                 next: T2) -> Combined<T1, T2>
+	{
 		Combined(accumulated, next)
 	}
 
@@ -20,11 +22,17 @@ public enum AtomicTransitionBuilder {
 		}
 	}
 
-	public static func buildEither<TrueTransition: AtomicTransition, FalseTransition: AtomicTransition>(first component: TrueTransition) -> _ConditionalTransition<TrueTransition, FalseTransition> {
+	public static func buildEither<TrueTransition: AtomicTransition,
+		FalseTransition: AtomicTransition>(first component: TrueTransition)
+		-> _ConditionalTransition<TrueTransition, FalseTransition>
+	{
 		_ConditionalTransition(trueTransition: component)
 	}
 
-	public static func buildEither<TrueTransition: AtomicTransition, FalseTransition: AtomicTransition>(second component: FalseTransition) -> _ConditionalTransition<TrueTransition, FalseTransition> {
+	public static func buildEither<TrueTransition: AtomicTransition,
+		FalseTransition: AtomicTransition>(second component: FalseTransition)
+		-> _ConditionalTransition<TrueTransition, FalseTransition>
+	{
 		_ConditionalTransition(falseTransition: component)
 	}
 }
@@ -50,7 +58,10 @@ extension _OptionalTransition: MirrorableAtomicTransition where Transition: Mirr
 extension _OptionalTransition: Equatable where Transition: Equatable {}
 extension _OptionalTransition: Hashable where Transition: Hashable {}
 
-public struct _ConditionalTransition<TrueTransition: AtomicTransition, FalseTransition: AtomicTransition>: AtomicTransition {
+public struct _ConditionalTransition<
+	TrueTransition: AtomicTransition,
+	FalseTransition: AtomicTransition,
+>: AtomicTransition {
 	private typealias Transition = _Either<TrueTransition, FalseTransition>
 	private let transition: Transition
 
@@ -72,7 +83,9 @@ public struct _ConditionalTransition<TrueTransition: AtomicTransition, FalseTran
 	}
 }
 
-extension _ConditionalTransition: MirrorableAtomicTransition where TrueTransition: MirrorableAtomicTransition, FalseTransition: MirrorableAtomicTransition {
+extension _ConditionalTransition: MirrorableAtomicTransition where TrueTransition: MirrorableAtomicTransition,
+	FalseTransition: MirrorableAtomicTransition
+{
 	public func mirrored() -> _ConditionalTransition<TrueTransition.Mirrored, FalseTransition.Mirrored> {
 		switch transition {
 		case let .left(trueTransition):

--- a/Sources/AtomicTransition/AtomicTransitionBuilder.swift
+++ b/Sources/AtomicTransition/AtomicTransitionBuilder.swift
@@ -88,7 +88,8 @@ public struct _ConditionalTransition<
 	}
 }
 
-extension _ConditionalTransition: MirrorableAtomicTransition where TrueTransition: MirrorableAtomicTransition,
+extension _ConditionalTransition: MirrorableAtomicTransition where
+	TrueTransition: MirrorableAtomicTransition,
 	FalseTransition: MirrorableAtomicTransition
 {
 	public func mirrored() -> _ConditionalTransition<TrueTransition.Mirrored, FalseTransition.Mirrored> {

--- a/Sources/AtomicTransition/AtomicTransitionBuilder.swift
+++ b/Sources/AtomicTransition/AtomicTransitionBuilder.swift
@@ -8,9 +8,10 @@ public enum AtomicTransitionBuilder {
 		first
 	}
 
-	public static func buildPartialBlock<T1: AtomicTransition, T2: AtomicTransition>(accumulated: T1,
-	                                                                                 next: T2) -> Combined<T1, T2>
-	{
+	public static func buildPartialBlock<T1: AtomicTransition, T2: AtomicTransition>(
+		accumulated: T1,
+		next: T2,
+	) -> Combined<T1, T2> {
 		Combined(accumulated, next)
 	}
 
@@ -22,17 +23,21 @@ public enum AtomicTransitionBuilder {
 		}
 	}
 
-	public static func buildEither<TrueTransition: AtomicTransition,
-		FalseTransition: AtomicTransition>(first component: TrueTransition)
-		-> _ConditionalTransition<TrueTransition, FalseTransition>
-	{
+	public static func buildEither<
+		TrueTransition: AtomicTransition,
+		FalseTransition: AtomicTransition,
+	>(
+		first component: TrueTransition,
+	) -> _ConditionalTransition<TrueTransition, FalseTransition> {
 		_ConditionalTransition(trueTransition: component)
 	}
 
-	public static func buildEither<TrueTransition: AtomicTransition,
-		FalseTransition: AtomicTransition>(second component: FalseTransition)
-		-> _ConditionalTransition<TrueTransition, FalseTransition>
-	{
+	public static func buildEither<
+		TrueTransition: AtomicTransition,
+		FalseTransition: AtomicTransition,
+	>(
+		second component: FalseTransition,
+	) -> _ConditionalTransition<TrueTransition, FalseTransition> {
 		_ConditionalTransition(falseTransition: component)
 	}
 }

--- a/Sources/AtomicTransition/Combined.swift
+++ b/Sources/AtomicTransition/Combined.swift
@@ -20,7 +20,9 @@ public struct Combined<TransitionA: AtomicTransition, TransitionB: AtomicTransit
 	}
 }
 
-extension Combined: MirrorableAtomicTransition where TransitionA: MirrorableAtomicTransition, TransitionB: MirrorableAtomicTransition {
+extension Combined: MirrorableAtomicTransition where TransitionA: MirrorableAtomicTransition,
+	TransitionB: MirrorableAtomicTransition
+{
 	public func mirrored() -> Combined<TransitionA.Mirrored, TransitionB.Mirrored> {
 		.init(transitionA.mirrored(), transitionB.mirrored())
 	}

--- a/Sources/AtomicTransition/Combined.swift
+++ b/Sources/AtomicTransition/Combined.swift
@@ -20,7 +20,8 @@ public struct Combined<TransitionA: AtomicTransition, TransitionB: AtomicTransit
 	}
 }
 
-extension Combined: MirrorableAtomicTransition where TransitionA: MirrorableAtomicTransition,
+extension Combined: MirrorableAtomicTransition where
+	TransitionA: MirrorableAtomicTransition,
 	TransitionB: MirrorableAtomicTransition
 {
 	public func mirrored() -> Combined<TransitionA.Mirrored, TransitionB.Mirrored> {

--- a/Sources/NavigationTransition/Combined.swift
+++ b/Sources/NavigationTransition/Combined.swift
@@ -11,7 +11,12 @@ extension CustomNavigationTransition {
 				let handler: CustomNavigationTransition.TransientHandler
 
 				@inlinable
-				func transition(from fromView: TransientView, to toView: TransientView, for operation: TransitionOperation, in container: Container) {
+				func transition(
+					from fromView: TransientView,
+					to toView: TransientView,
+					for operation: TransitionOperation,
+					in container: Container,
+				) {
 					handler(fromView, toView, operation, container)
 				}
 			}
@@ -33,7 +38,10 @@ extension CustomNavigationTransition {
 	}
 }
 
-public struct Combined<TransitionA: NavigationTransitionProtocol, TransitionB: NavigationTransitionProtocol>: NavigationTransitionProtocol {
+public struct Combined<
+	TransitionA: NavigationTransitionProtocol,
+	TransitionB: NavigationTransitionProtocol,
+>: NavigationTransitionProtocol {
 	private let transitionA: TransitionA
 	private let transitionB: TransitionB
 

--- a/Sources/NavigationTransition/NavigationTransitionBuilder.swift
+++ b/Sources/NavigationTransition/NavigationTransitionBuilder.swift
@@ -4,7 +4,10 @@ public enum NavigationTransitionBuilder {
 		first
 	}
 
-	public static func buildPartialBlock<T1: NavigationTransitionProtocol, T2: NavigationTransitionProtocol>(accumulated: T1, next: T2) -> Combined<T1, T2> {
+	public static func buildPartialBlock<T1: NavigationTransitionProtocol, T2: NavigationTransitionProtocol>(
+		accumulated: T1,
+		next: T2,
+	) -> Combined<T1, T2> {
 		Combined(accumulated, next)
 	}
 
@@ -16,11 +19,17 @@ public enum NavigationTransitionBuilder {
 		}
 	}
 
-	public static func buildEither<TrueTransition: NavigationTransitionProtocol, FalseTransition: NavigationTransitionProtocol>(first component: TrueTransition) -> _ConditionalTransition<TrueTransition, FalseTransition> {
+	public static func buildEither<
+		TrueTransition: NavigationTransitionProtocol,
+		FalseTransition: NavigationTransitionProtocol,
+	>(first component: TrueTransition) -> _ConditionalTransition<TrueTransition, FalseTransition> {
 		_ConditionalTransition(trueTransition: component)
 	}
 
-	public static func buildEither<TrueTransition: NavigationTransitionProtocol, FalseTransition: NavigationTransitionProtocol>(second component: FalseTransition) -> _ConditionalTransition<TrueTransition, FalseTransition> {
+	public static func buildEither<
+		TrueTransition: NavigationTransitionProtocol,
+		FalseTransition: NavigationTransitionProtocol,
+	>(second component: FalseTransition) -> _ConditionalTransition<TrueTransition, FalseTransition> {
 		_ConditionalTransition(falseTransition: component)
 	}
 }
@@ -42,7 +51,10 @@ public struct _OptionalTransition<Transition: NavigationTransitionProtocol>: Nav
 	}
 }
 
-public struct _ConditionalTransition<TrueTransition: NavigationTransitionProtocol, FalseTransition: NavigationTransitionProtocol>: NavigationTransitionProtocol {
+public struct _ConditionalTransition<
+	TrueTransition: NavigationTransitionProtocol,
+	FalseTransition: NavigationTransitionProtocol,
+>: NavigationTransitionProtocol {
 	private typealias Transition = _Either<TrueTransition, FalseTransition>
 	private let transition: Transition
 

--- a/Sources/NavigationTransition/NavigationTransitionProtocol.swift
+++ b/Sources/NavigationTransition/NavigationTransitionProtocol.swift
@@ -49,7 +49,8 @@ public protocol NavigationTransitionProtocol {
 	///
 	/// Do not invoke this property directly.
 	///
-	/// - Important: If your transition implements the ``transition(from:to:for:in:)-22zdm`` method, it will take precedence
+	/// - Important: If your transition implements the ``transition(from:to:for:in:)-22zdm`` method, it will take
+	/// precedence
 	///   over this property, and only ``transition(from:to:for:in:)-22zdm`` will be called by the animator.
 	@NavigationTransitionBuilder
 	var body: Body { get }

--- a/Sources/NavigationTransition/NavigationTransitionProtocol.swift
+++ b/Sources/NavigationTransition/NavigationTransitionProtocol.swift
@@ -50,8 +50,7 @@ public protocol NavigationTransitionProtocol {
 	/// Do not invoke this property directly.
 	///
 	/// - Important: If your transition implements the ``transition(from:to:for:in:)-22zdm`` method, it will take
-	/// precedence
-	///   over this property, and only ``transition(from:to:for:in:)-22zdm`` will be called by the animator.
+	///   precedence over this property, and only ``transition(from:to:for:in:)-22zdm`` will be called by the animator.
 	@NavigationTransitionBuilder
 	var body: Body { get }
 }

--- a/Sources/NavigationTransition/Pick.swift
+++ b/Sources/NavigationTransition/Pick.swift
@@ -1,4 +1,5 @@
-/// Used to isolate the push portion of a full `NavigationTransitionProtocol` and execute it on push, ignoring the pop portion.
+/// Used to isolate the push portion of a full `NavigationTransitionProtocol` and execute it on push, ignoring the pop
+/// portion.
 public struct PickPush<Transition: NavigationTransitionProtocol>: NavigationTransitionProtocol {
 	private let transition: Transition
 
@@ -24,7 +25,8 @@ public struct PickPush<Transition: NavigationTransitionProtocol>: NavigationTran
 extension PickPush: Equatable where Transition: Equatable {}
 extension PickPush: Hashable where Transition: Hashable {}
 
-/// Used to isolate the pop portion of a full `NavigationTransitionProtocol` and execute it on pop, ignoring the push portion.
+/// Used to isolate the pop portion of a full `NavigationTransitionProtocol` and execute it on pop, ignoring the push
+/// portion.
 public struct PickPop<Transition: NavigationTransitionProtocol>: NavigationTransitionProtocol {
 	private let transition: Transition
 

--- a/Sources/SwiftUINavigationTransitions/SwiftUISupport.swift
+++ b/Sources/SwiftUINavigationTransitions/SwiftUISupport.swift
@@ -10,9 +10,7 @@ extension View {
 	) -> some View {
 		self.introspect(
 			.navigationView(style: .stack),
-			on: .iOS(.v13...),
-			.tvOS(.v13...),
-			.visionOS(.v1...),
+			on: .iOS(.v13...), .tvOS(.v13...), .visionOS(.v1...),
 			scope: [.receiver, .ancestor],
 		) { controller in
 			controller.setNavigationTransition(transition, interactivity: interactivity)

--- a/Sources/SwiftUINavigationTransitions/SwiftUISupport.swift
+++ b/Sources/SwiftUINavigationTransitions/SwiftUISupport.swift
@@ -10,7 +10,9 @@ extension View {
 	) -> some View {
 		self.introspect(
 			.navigationView(style: .stack),
-			on: .iOS(.v13...), .tvOS(.v13...), .visionOS(.v1...),
+			on: .iOS(.v13...),
+			.tvOS(.v13...),
+			.visionOS(.v1...),
 			scope: [.receiver, .ancestor],
 		) { controller in
 			controller.setNavigationTransition(transition, interactivity: interactivity)

--- a/Sources/UIKitNavigationTransitions/Delegate.swift
+++ b/Sources/UIKitNavigationTransitions/Delegate.swift
@@ -81,9 +81,9 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
 		transitionAnimator(for: transitionContext).startAnimation()
 	}
 
-	func interruptibleAnimator(using transitionContext: any UIViewControllerContextTransitioning)
-		-> any UIViewImplicitlyAnimating
-	{
+	func interruptibleAnimator(
+		using transitionContext: any UIViewControllerContextTransitioning,
+	) -> any UIViewImplicitlyAnimating {
 		transitionAnimator(for: transitionContext)
 	}
 
@@ -93,9 +93,9 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
 
 	private var cachedAnimators: [ObjectIdentifier: UIViewPropertyAnimator] = .init(minimumCapacity: 1)
 
-	private func transitionAnimator(for transitionContext: any UIViewControllerContextTransitioning)
-		-> UIViewPropertyAnimator
-	{
+	private func transitionAnimator(
+		for transitionContext: any UIViewControllerContextTransitioning,
+	) -> UIViewPropertyAnimator {
 		if let cached = cachedAnimators[ObjectIdentifier(transitionContext)] {
 			return cached
 		}

--- a/Sources/UIKitNavigationTransitions/Delegate.swift
+++ b/Sources/UIKitNavigationTransitions/Delegate.swift
@@ -13,15 +13,26 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
 		self.baseDelegate = baseDelegate
 	}
 
-	func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+	func navigationController(
+		_ navigationController: UINavigationController,
+		willShow viewController: UIViewController,
+		animated: Bool,
+	) {
 		baseDelegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
 	}
 
-	func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+	func navigationController(
+		_ navigationController: UINavigationController,
+		didShow viewController: UIViewController,
+		animated: Bool,
+	) {
 		baseDelegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
 	}
 
-	func navigationController(_ navigationController: UINavigationController, interactionControllerFor animationController: any UIViewControllerAnimatedTransitioning) -> (any UIViewControllerInteractiveTransitioning)? {
+	func navigationController(
+		_ navigationController: UINavigationController,
+		interactionControllerFor animationController: any UIViewControllerAnimatedTransitioning,
+	) -> (any UIViewControllerInteractiveTransitioning)? {
 		if !transition.isDefault {
 			interactionController
 		} else {
@@ -29,7 +40,12 @@ final class NavigationTransitionDelegate: NSObject, UINavigationControllerDelega
 		}
 	}
 
-	func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationController.Operation, from fromVC: UIViewController, to toVC: UIViewController) -> (any UIViewControllerAnimatedTransitioning)? {
+	func navigationController(
+		_ navigationController: UINavigationController,
+		animationControllerFor operation: UINavigationController.Operation,
+		from fromVC: UIViewController,
+		to toVC: UIViewController,
+	) -> (any UIViewControllerAnimatedTransitioning)? {
 		if
 			!transition.isDefault,
 			let animation = transition.animation,
@@ -65,7 +81,9 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
 		transitionAnimator(for: transitionContext).startAnimation()
 	}
 
-	func interruptibleAnimator(using transitionContext: any UIViewControllerContextTransitioning) -> any UIViewImplicitlyAnimating {
+	func interruptibleAnimator(using transitionContext: any UIViewControllerContextTransitioning)
+		-> any UIViewImplicitlyAnimating
+	{
 		transitionAnimator(for: transitionContext)
 	}
 
@@ -75,7 +93,9 @@ final class NavigationTransitionAnimatorProvider: NSObject, UIViewControllerAnim
 
 	private var cachedAnimators: [ObjectIdentifier: UIViewPropertyAnimator] = .init(minimumCapacity: 1)
 
-	private func transitionAnimator(for transitionContext: any UIViewControllerContextTransitioning) -> UIViewPropertyAnimator {
+	private func transitionAnimator(for transitionContext: any UIViewControllerContextTransitioning)
+		-> UIViewPropertyAnimator
+	{
 		if let cached = cachedAnimators[ObjectIdentifier(transitionContext)] {
 			return cached
 		}

--- a/Sources/UIKitNavigationTransitions/UIKitSupport.swift
+++ b/Sources/UIKitNavigationTransitions/UIKitSupport.swift
@@ -198,8 +198,7 @@ extension UINavigationController {
 		try #once {
 			try #swizzle(
 				UINavigationController.setViewControllers,
-				params: [UIViewController].self,
-				Bool.self,
+				params: [UIViewController].self, Bool.self,
 			) { $self, viewControllers, animated in
 				if let transitionDelegate = self.customDelegate {
 					self.setViewControllers(viewControllers, animated: transitionDelegate.transition.animation != nil)
@@ -210,8 +209,7 @@ extension UINavigationController {
 
 			try #swizzle(
 				UINavigationController.pushViewController,
-				params: UIViewController.self,
-				Bool.self,
+				params: UIViewController.self, Bool.self,
 			) { $self, viewController, animated in
 				if let transitionDelegate = self.customDelegate {
 					self.pushViewController(viewController, animated: transitionDelegate.transition.animation != nil)
@@ -234,8 +232,7 @@ extension UINavigationController {
 
 			try #swizzle(
 				UINavigationController.popToViewController,
-				params: UIViewController.self,
-				Bool.self,
+				params: UIViewController.self, Bool.self,
 				returning: [UIViewController]?.self,
 			) { $self, viewController, animated in
 				if let transitionDelegate = self.customDelegate {

--- a/Sources/UIKitNavigationTransitions/UIKitSupport.swift
+++ b/Sources/UIKitNavigationTransitions/UIKitSupport.swift
@@ -198,7 +198,8 @@ extension UINavigationController {
 		try #once {
 			try #swizzle(
 				UINavigationController.setViewControllers,
-				params: [UIViewController].self, Bool.self,
+				params: [UIViewController].self,
+				Bool.self,
 			) { $self, viewControllers, animated in
 				if let transitionDelegate = self.customDelegate {
 					self.setViewControllers(viewControllers, animated: transitionDelegate.transition.animation != nil)
@@ -209,7 +210,8 @@ extension UINavigationController {
 
 			try #swizzle(
 				UINavigationController.pushViewController,
-				params: UIViewController.self, Bool.self,
+				params: UIViewController.self,
+				Bool.self,
 			) { $self, viewController, animated in
 				if let transitionDelegate = self.customDelegate {
 					self.pushViewController(viewController, animated: transitionDelegate.transition.animation != nil)
@@ -232,7 +234,8 @@ extension UINavigationController {
 
 			try #swizzle(
 				UINavigationController.popToViewController,
-				params: UIViewController.self, Bool.self,
+				params: UIViewController.self,
+				Bool.self,
 				returning: [UIViewController]?.self,
 			) { $self, viewController, animated in
 				if let transitionDelegate = self.customDelegate {

--- a/Sources/UIKitNavigationTransitions/UIKitSupport.swift
+++ b/Sources/UIKitNavigationTransitions/UIKitSupport.swift
@@ -329,7 +329,8 @@ final class NavigationGestureRecognizerDelegate: NSObject, UIGestureRecognizerDe
 	// TODO: swizzle instead
 	func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
 		let isNotOnRoot = navigationController.viewControllers.count > 1
-		let noModalIsPresented = navigationController.presentedViewController == nil // TODO: check if this check is still needed after iOS 17 public release
+		let noModalIsPresented = navigationController
+			.presentedViewController == nil // TODO: check if this check is still needed after iOS 17 public release
 		return isNotOnRoot && noModalIsPresented
 	}
 }

--- a/Tests/AnimatorTests/AnimatorTransientViewTests.swift
+++ b/Tests/AnimatorTests/AnimatorTransientViewTests.swift
@@ -20,7 +20,10 @@ extension AnimatorTransientViewTests {
 		XCTAssertEqual(sut.frame.origin.y, 20, accuracy: 0.000001)
 		XCTAssertEqual(sut.frame.size.width, 120, accuracy: 0.000001)
 		XCTAssertEqual(sut.frame.size.height, 160, accuracy: 0.000001)
-		XCTAssertEqual(sut.transform3D, .identity.translated(x: 50, y: 60, z: 0).scaled(4).rotated(by: .pi, x: 0, y: 0, z: 1))
+		XCTAssertEqual(
+			sut.transform3D,
+			.identity.translated(x: 50, y: 60, z: 0).scaled(4).rotated(by: .pi, x: 0, y: 0, z: 1),
+		)
 
 		let expectedProperties = AnimatorTransientView.Properties(
 			alpha: 0.5,

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
 min_version = "2026.8.6"
 
+[settings]
+not_found_system_fallback = false
+
 [tool_config]
 locked = true
 


### PR DESCRIPTION
- Configure SwiftFormat for 120-column wrapping with tabs counted as two columns.
- Normalize multiline arguments, parameters, conditional assignments, function chains, and block comments.
- Prevent Mise from falling back to same-named system binaries.
- Apply and review the resulting formatter output.